### PR TITLE
fix(annotations): fix missing annotations & readme / makefile fix typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,12 @@ PROJECT_NAME := provider-kubernetes
 PROJECT_REPO := github.com/crossplane-contrib/$(PROJECT_NAME)
 
 PLATFORMS ?= linux_amd64 linux_arm64
-include build/makelib/common.mk
+
+# -include will silently skip missing files, which allows us
+# to load those files with a target in the Makefile. If only
+# "include" was used, the make command would fail and refuse
+# to run a target until the include commands succeeded.
+-include build/makelib/common.mk
 
 # ====================================================================================
 # Setup Output

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ kubectl crossplane install provider crossplane/provider-kubernetes:main
 You may also manually install `provider-kubernetes` by creating a `Provider` directly:
 
 ```yaml
-apiVersion: pkg.crossplane.io/v1alpha1
+apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
   name: provider-kubernetes

--- a/internal/controller/object/object.go
+++ b/internal/controller/object/object.go
@@ -36,6 +36,7 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -223,9 +224,10 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalCreation{}, err
 	}
 
-	obj.SetAnnotations(map[string]string{
+	meta.AddAnnotations(obj, map[string]string{
 		v1.LastAppliedConfigAnnotation: string(cr.Spec.ForProvider.Manifest.Raw),
 	})
+
 	if err := c.client.Create(ctx, obj); err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreateObject)
 	}
@@ -247,9 +249,10 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalUpdate{}, err
 	}
 
-	obj.SetAnnotations(map[string]string{
+	meta.AddAnnotations(obj, map[string]string{
 		v1.LastAppliedConfigAnnotation: string(cr.Spec.ForProvider.Manifest.Raw),
 	})
+
 	if err := c.client.Apply(ctx, obj); err != nil {
 		return managed.ExternalUpdate{}, errors.Wrap(err, errApplyObject)
 	}


### PR DESCRIPTION
Signed-off-by: Christopher Haar <chhaar30@googlemail.com>

### Description of your changes

1.  fix missing annotations after apply k8s objects via provider-kubernetes in compositions - removed obj.SetAnnotations 
old behavior:
```
kubectl describe object.kubernetes.crossplane.io/example
Name:         example
Namespace:    
Labels:       crossplane.io/claim-name=
              crossplane.io/claim-namespace=
              crossplane.io/composite=example
Annotations:  crossplane.io/external-name: example
API Version:  kubernetes.crossplane.io/v1alpha1
Kind:         Object
Metadata:
  Creation Timestamp:  2021-07-25T21:25:43Z
  Finalizers:
    finalizer.managedresource.crossplane.io
  Generate Name:  example-
  Generation:     1
  Owner References:
    API Version:     platform.xxx.intern/v1alpha1
    Controller:      true
    Kind:            Secret
    Name:            example
    UID:             e4490153-2bd7-4111-a590-5f5af02b75b9
  Resource Version:  1768822
  Self Link:         /apis/kubernetes.crossplane.io/v1alpha1/objects/example
  UID:               28587d65-322a-4dd0-a321-c769674a4613
Spec:
  For Provider:
    Manifest:
      API Version:  v1
      Data:
        Team:  xxxx
      Kind:    Secret
      Metadata:
        Annotations:
          abc/autogenerate:  password
          def/type:          string
        Namespace:                                       api-service
      Type:                                              Opaque
  Provider Config Ref:
    Name:  kubernetes-provider
Status:
  At Provider:
    Manifest:
      API Version:  v1
      Data:
        Team:  xxxx
      Kind:    Secret
      Metadata:
        Annotations:
          kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"v1","data":{"team":"xxxx"},"kind":"Secret","metadata":{"annotations":{"abc/autogenerate":"password","def/type":"string"},"namespace":"api-service"},"type":"Opaque"}
        Creation Timestamp:                                  2021-07-25T21:25:43Z
        Name:                                                example
        Namespace:                                           api-service
        Resource Version:                                    1768821
        Self Link:                                           /api/v1/namespaces/api-service/secrets/example
        UID:                                                 f0ca82c6-6c0b-4657-979e-4d8f17d01f40
      Type:                                                  Opaque
```

fixed behavior
```
kubectl describe object.kubernetes.crossplane.io/example
Name:         example
Namespace:    
Labels:       crossplane.io/claim-name=
              crossplane.io/claim-namespace=
              crossplane.io/composite=example
Annotations:  crossplane.io/external-name: example
API Version:  kubernetes.crossplane.io/v1alpha1
Kind:         Object
Metadata:
  Creation Timestamp:  2021-07-25T21:25:43Z
  Finalizers:
    finalizer.managedresource.crossplane.io
  Generate Name:  example-
  Generation:     1
  Owner References:
    API Version:     platform.xxx.intern/v1alpha1
    Controller:      true
    Kind:            Secret
    Name:            example
    UID:             e4490153-2bd7-4111-a590-5f5af02b75b9
  Resource Version:  1768822
  Self Link:         /apis/kubernetes.crossplane.io/v1alpha1/objects/example
  UID:               28587d65-322a-4dd0-a321-c769674a4613
Spec:
  For Provider:
    Manifest:
      API Version:  v1
      Data:
        Team:  xxxx
      Kind:    Secret
      Metadata:
        Annotations:
          abc/autogenerate:  password
          def/type:          string
        Namespace:                                       api-service
      Type:                                              Opaque
  Provider Config Ref:
    Name:  kubernetes-provider
Status:
  At Provider:
    Manifest:
      API Version:  v1
      Data:
        Team:  xxxx
      Kind:    Secret
      Metadata:
        Annotations:
          abc/autogenerate: password
          def/type: string
          kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"v1","data":{"team":"xxxx"},"kind":"Secret","metadata":{"annotations":{"abc/autogenerate":"password","def/type":"string"},"namespace":"api-service"},"type":"Opaque"}
        Creation Timestamp:                                  2021-07-25T21:25:43Z
        Name:                                                example
        Namespace:                                           api-service
        Resource Version:                                    1768821
        Self Link:                                           /api/v1/namespaces/api-service/secrets/example
        UID:                                                 f0ca82c6-6c0b-4657-979e-4d8f17d01f40
      Type:                                                  Opaque
```


2.  fix Readme apiVersion: pkg.crossplane.io/v1alpha1 to apiVersion: pkg.crossplane.io/v1
3.  fix Makefile include without make submodule `-include will silently skip missing files, which allows us to load those files with a target in the Makefile.`

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
make reviewable

[contribution process]: https://git.io/fj2m9
