### PR TITLE
Add canonical categories to ProviderConfig

### DIFF
--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -71,7 +71,7 @@ type ProviderConfigStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="SECRET-NAME",type="string",JSONPath=".spec.credentials.secretRef.name",priority=1
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,kubernetes}
 type ProviderConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
### Description of your changes

Add categories to the ProviderConfig to be in line with other providers like the helm provider:
https://github.com/crossplane-contrib/provider-helm/blob/master/apis/v1beta1/types.go#L76
