### PR TITLE
Remove clean.crds from Makefile - fixes #48

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,14 +70,6 @@ cobertura:
 		grep -v zz_generated.deepcopy | \
 		$(GOCOVER_COBERTURA) > $(GO_TEST_OUTPUT)/cobertura-coverage.xml
 
-crds.clean:
-	@$(INFO) cleaning generated CRDs
-	@find package/crds -name *.yaml -exec sed -i.sed -e '1,2d' {} \; || $(FAIL)
-	@find package/crds -name *.yaml.sed -delete || $(FAIL)
-	@$(OK) cleaned generated CRDs
-
-generate.done: crds.clean
-
 # integration tests
 e2e.run: test-integration
 

--- a/package/crds/kubernetes.crossplane.io_objects.yaml
+++ b/package/crds/kubernetes.crossplane.io_objects.yaml
@@ -1,3 +1,5 @@
+---
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/package/crds/kubernetes.crossplane.io_providerconfigs.yaml
+++ b/package/crds/kubernetes.crossplane.io_providerconfigs.yaml
@@ -1,3 +1,5 @@
+---
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/package/crds/kubernetes.crossplane.io_providerconfigusages.yaml
+++ b/package/crds/kubernetes.crossplane.io_providerconfigusages.yaml
@@ -1,3 +1,5 @@
+---
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:


### PR DESCRIPTION
Signed-off-by: Bob Haddleton <bob.haddleton@nokia.com>

### Description of your changes
Removed the clean.crds target from the Makefile which was removing the first two lines of the generated CRDs

Fixes #48 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Verified that the generated CRDs are now valid.

[contribution process]: https://git.io/fj2m9
