### PR TITLE
Add ownerReference for dependsOn references

### DIFF
--- a/internal/controller/object/object.go
+++ b/internal/controller/object/object.go
@@ -405,6 +405,14 @@ func (c *external) resolveReferencies(ctx context.Context, obj *v1alpha1.Object)
 				return errors.Wrap(err, errPatchFromReferencedResource)
 			}
 		}
+		// Dependencies will set a finalizer on the referenced resource.  Add an ownerReference
+		// on the Object to support Foreground Cascading Deletion.
+		if ref.DependsOn != nil {
+			or := meta.AsOwner(meta.TypedReferenceTo(res, res.GetObjectKind().GroupVersionKind()))
+			t := true
+			or.BlockOwnerDeletion = &t
+			meta.AddOwnerReference(obj, or)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Bob Haddleton <bob.haddleton@nokia.com>

### Description of your changes

Add an ownerReference along with the finalizer for dependent resources

Fixes #46 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Tested in a local cluster, using examples/references/depends-on-resource.yaml as a test sample.

This file creates a ConfigMap called "bar" and an Object called "foo" which creates another ConfigMap, also called "foo", with a dependsOn reference to "bar".

I confirmed that:
- provider-kubernetes adds a finalizer to "bar":
```
finalizers:
  - kubernetes.crossplane.io/referred-by-object-d74a5845-2645-4931-9f7a-868814c1edb8
```
- provider-kubernetes adds an ownerReference to the Object which points at "bar":
```
  ownerReferences:
  - apiVersion: v1
    blockOwnerDeletion: true
    kind: ConfigMap
    name: bar
    uid: aa019dcd-3045-44ea-9835-bf9643ce9d49
```
- When "bar" is deleted using foreground cascading deletion, a foregroundDeletion finalizer is added to "bar":
```
  deletionGracePeriodSeconds: 0
  deletionTimestamp: "2022-09-25T02:33:42Z"
  finalizers:
  - kubernetes.crossplane.io/referred-by-object-d74a5845-2645-4931-9f7a-868814c1edb8
  - foregroundDeletion
```
- Deleting "bar" with foreground cascading deletion will first delete the Object "foo", since it is "owned" by "bar", which deletes ConfigMap "foo" and removes the finalizer from "bar", and then "bar" is deleted.

So if we call "bar" the Database Server and "foo" the Database, we can make the Database dependOn the Database Server and ensure that the Database gets deleted before the Database Server.

[contribution process]: https://git.io/fj2m9
