### PR TITLE
Fix stuck reference finalizers

### DIFF
--- a/internal/controller/object/object_test.go
+++ b/internal/controller/object/object_test.go
@@ -1364,7 +1364,7 @@ func Test_objFinalizer_RemoveFinalizer(t *testing.T) {
 				err: errors.Wrap(
 					errors.Wrap(errBoom,
 						errRemoveReferenceFinalizer), errRemoveFinalizer),
-				finalizers: []string{},
+				finalizers: []string{objFinalizerName},
 			},
 		},
 		"Success": {

--- a/internal/controller/object/object_test.go
+++ b/internal/controller/object/object_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1274,7 +1275,8 @@ func Test_objFinalizer_RemoveFinalizer(t *testing.T) {
 		mg     resource.Managed
 	}
 	type want struct {
-		err error
+		err        error
+		finalizers []string
 	}
 	cases := map[string]struct {
 		args
@@ -1285,7 +1287,8 @@ func Test_objFinalizer_RemoveFinalizer(t *testing.T) {
 				mg: notKubernetesObject{},
 			},
 			want: want{
-				err: errors.New(errNotKubernetesObject),
+				err:        errors.New(errNotKubernetesObject),
+				finalizers: []string{},
 			},
 		},
 		"FailedToRemoveObjectFinalizer": {
@@ -1300,7 +1303,8 @@ func Test_objFinalizer_RemoveFinalizer(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, errRemoveFinalizer),
+				err:        errors.Wrap(errBoom, errRemoveFinalizer),
+				finalizers: []string{},
 			},
 		},
 		"NoObjectFinalizerExists": {
@@ -1308,7 +1312,8 @@ func Test_objFinalizer_RemoveFinalizer(t *testing.T) {
 				mg: kubernetesObject(),
 			},
 			want: want{
-				err: nil,
+				err:        nil,
+				finalizers: nil,
 			},
 		},
 		"NoReferenceFinalizerExists": {
@@ -1328,7 +1333,8 @@ func Test_objFinalizer_RemoveFinalizer(t *testing.T) {
 				},
 			},
 			want: want{
-				err: nil,
+				err:        nil,
+				finalizers: []string{},
 			},
 		},
 		"FailedToRemoveReferenceFinalizer": {
@@ -1358,6 +1364,7 @@ func Test_objFinalizer_RemoveFinalizer(t *testing.T) {
 				err: errors.Wrap(
 					errors.Wrap(errBoom,
 						errRemoveReferenceFinalizer), errRemoveFinalizer),
+				finalizers: []string{},
 			},
 		},
 		"Success": {
@@ -1378,7 +1385,8 @@ func Test_objFinalizer_RemoveFinalizer(t *testing.T) {
 				},
 			},
 			want: want{
-				err: nil,
+				err:        nil,
+				finalizers: []string{},
 			},
 		},
 	}
@@ -1387,9 +1395,17 @@ func Test_objFinalizer_RemoveFinalizer(t *testing.T) {
 			f := &objFinalizer{
 				client: tc.args.client,
 			}
+
 			gotErr := f.RemoveFinalizer(context.Background(), tc.args.mg)
 			if diff := cmp.Diff(tc.want.err, gotErr, test.EquateErrors()); diff != "" {
-				t.Fatalf("f.RemoveFinalizer(...): -want error, +got error: %s", diff)
+				t.Errorf("f.RemoveFinalizer(...): -want error, +got error: %s", diff)
+			}
+
+			if _, ok := tc.args.mg.(*v1alpha1.Object); ok {
+				sort := cmpopts.SortSlices(func(a, b string) bool { return a < b })
+				if diff := cmp.Diff(tc.want.finalizers, tc.args.mg.GetFinalizers(), sort); diff != "" {
+					t.Errorf("managed resource finalizers: -want, +got: %s", diff)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This PR fixes an error that may leave lingering finalizers on resources referenced by deleted `Objects` under certain conditions. Such resources won't be deleted until the finalizers are removed out-of-band.

When provider-kubernetes reconciles an `Object`, it applies finalizers to any resources that it references. Then when provider-kubernetes reconciles the deleted `Object`, it removes all the reference finalizers. This ensures that the referenced resources aren't deleted until after the `Object` is deleted.

When reconciling a deleted `Object`, provider-kubernetes first removes its finalizer on the `Object`, and then removes the finalizers from any referenced resources. If removing reference finalizers fails with an error, provider-kubernetes re-queues reconciliation. However because the `Object` finalizer was removed, it may have no remaining finalizers, and may be cleaned up before the next reconciliation. If that occurs, the `Object` can no longer be reconciled, and any lingering reference finalizers will remain until removed OOB of provider-kubernetes reconciliation.

The following log excerpt demonstrates the above sequence of events. In this example, removing a reference finalizer failed due to a version conflict on the referenced resource. 

```
2022-09-13T17:16:21.564Z	DEBUG	provider-kubernetes	Deleting	{"resource": {"kind":"Object","apiVersion":"kubernetes.crossplane.io/v1alpha1","metadata":{"name":"e05b83e7-21b1-4484-b0bb-68de83724d68-zb5bm","generateName":"e05b83e7-21b1-4484-b0bb-68de83724d68-","uid":"6bd0201c-5b61-4e66-a461-43d22797d6ec","resourceVersion":"252208","generation":3,"creationTimestamp":"2022-09-13T17:10:54Z","deletionTimestamp":"2022-09-13T17:16:20Z","deletionGracePeriodSeconds":0,"labels":{"crossplane.io/claim-name":"","crossplane.io/claim-namespace":"","crossplane.io/composite":"e05b83e7-21b1-4484-b0bb-68de83724d68"},"annotations":{"crossplane.io/composition-resource-name":"propagate-gateway-token-signing-certificate","crossplane.io/external-create-pending":"2022-09-13T17:11:36Z","crossplane.io/external-create-succeeded":"2022-09-13T17:11:36Z","crossplane.io/external-name":"e05b83e7-21b1-4484-b0bb-68de83724d68-zb5bm"},"ownerReferences":[{"apiVersion":"mcp.upbound.io/v1alpha1","kind":"ManagedServices","name":"e05b83e7-21b1-4484-b0bb-68de83724d68","uid":"389f40ac-a96b-4671-8c2e-4211a0f20464","controller":true}],"finalizers":["finalizer.managedresource.crossplane.io"],"managedFields":[{"manager":"crossplane","operation":"Update","apiVersion":"kubernetes.crossplane.io/v1alpha1","time":"2022-09-13T17:10:53Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:crossplane.io/composition-resource-name":{}},"f:generateName":{},"f:labels":{".":{},"f:crossplane.io/claim-name":{},"f:crossplane.io/claim-namespace":{},"f:crossplane.io/composite":{}},"f:ownerReferences":{".":{},"k:{\"uid\":\"389f40ac-a96b-4671-8c2e-4211a0f20464\"}":{}}},"f:spec":{".":{},"f:deletionPolicy":{},"f:forProvider":{".":{},"f:manifest":{".":{},"f:apiVersion":{},"f:kind":{},"f:metadata":{".":{},"f:name":{},"f:namespace":{}}}},"f:managementPolicy":{},"f:providerConfigRef":{".":{},"f:name":{}},"f:references":{}}}},{"manager":"crossplane-kubernetes-provider","operation":"Update","apiVersion":"kubernetes.crossplane.io/v1alpha1","time":"2022-09-13T17:11:36Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:crossplane.io/external-create-pending":{},"f:crossplane.io/external-create-succeeded":{},"f:crossplane.io/external-name":{}},"f:finalizers":{".":{},"v:\"finalizer.managedresource.crossplane.io\"":{}}},"f:spec":{"f:forProvider":{"f:manifest":{"f:data":{".":{},"f:tls.crt":{}}}}}}},{"manager":"crossplane-kubernetes-provider","operation":"Update","apiVersion":"kubernetes.crossplane.io/v1alpha1","time":"2022-09-13T17:11:37Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{".":{},"f:atProvider":{".":{},"f:manifest":{".":{},"f:apiVersion":{},"f:data":{".":{},"f:tls.crt":{}},"f:kind":{},"f:metadata":{".":{},"f:annotations":{".":{},"f:kubectl.kubernetes.io/last-applied-configuration":{}},"f:creationTimestamp":{},"f:managedFields":{},"f:name":{},"f:namespace":{},"f:resourceVersion":{},"f:uid":{}},"f:type":{}}},"f:conditions":{}}},"subresource":"status"}]},"spec":{"providerConfigRef":{"name":"mcp-e05b83e7-21b1-4484-b0bb-68de83724d68"},"deletionPolicy":"Delete","managementPolicy":"Default","references":[{"dependsOn":{"apiVersion":"mcp.upbound.io/v1alpha1","kind":"KubeControlPlane","name":"e05b83e7-21b1-4484-b0bb-68de83724d68"}},{"patchesFrom":{"apiVersion":"v1","kind":"Secret","name":"cert-token-signing-gateway","namespace":"mcp-system","fieldPath":"data[tls.crt]"},"toFieldPath":"data[tls.crt]"}],"forProvider":{"manifest":{"apiVersion":"v1","data":{"tls.crt":"LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQ0lqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FnOEFNSUlDQ2dLQ0FnRUFzYXlMb1ZBcFhhc05jbVIwNmJmeQpKc0VPTWt0ZFRXc0toelVGZUxYV0tlT09SYzIvaExtNnpVVGRWUExXbkNvL3o2SEhqdXN1YWdzaHdlNlBPZnRCCjY5eEVHWmxzdFowMGRvMkk5b2lleTNXTlRkOUhjdGFXbEVRZFRsYWpxaVZ4UmR4dnEyZUtUNk1Ga1ZUd1N6RG8KM0t5VUdhazhzWVVZaUlQV3NKMWFhRklsR1ZvRGx0UHcxcThaQXpUMmJmQXA2bzZGYk03aitiQ0FiQTdRTlJBTQpEVUxvL2xRaVVKNHluVlpaNm9tbkp1TlBLeHNUSExSRHBrZndVditNZ21WbVREa0xUK1d2VjZ3bmlRaDRqemh5CnZ4Y3dENStDeHpqUWNYc01kTEUvcE0zYzY0RWNPWEJ3WVlnbXFzSjhrMjRhN3c4MU9rVXNCQmdVaERtOER2TFAKanNqVTJGOVdjWm9UN040T000a0RCMkFBZHIyNXhMbEtaTDl6dlpXMnF2VDYyVzRGYW5qeVdRMmU5ZGk2QVU2bQovdk4ra2xHMVV5MEJqSXN3ZTdkdEMwK1Jod2Y0ZkVLeW00bHlnOGV4eWhQVEJQWHYxa3dERnd3eitPMFdWcG02CmlKcWFFVVlTL2hqcndtZzJWTitLR3FYRGRwWXo0RGlWM0hYOGRPa3IyRWVSVUNzdUpleElmSEZuYndNYzZRalkKSldxWTB0YUdmNm8zK1IyZjU0Nko4bThpaHlWNDlHU0ZyMGlXd01paUxHNTJBQmVVZ2tyVjlzR2dnS1FnaDUzcgozYjE3Ny9ZMVpDQ2xsSDVVWHJESG1aSDJQNnh5MUtad1lzUjlrNGUrZXZieDdoNzFESlV3VjlITUthbCtBWTZjCjMxRmNhSHBHQ1JhVHlFb05HY1lUckxFQ0F3RUFBUT09Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo="},"kind":"Secret","metadata":{"name":"cert-token-signing-gateway-pub","namespace":"upbound-system"}}}},"status":{"conditions":[{"type":"Synced","status":"True","lastTransitionTime":"2022-09-13T17:11:37Z","reason":"ReconcileSuccess"},{"type":"Ready","status":"True","lastTransitionTime":"2022-09-13T17:11:37Z","reason":"Available"}],"atProvider":{"manifest":{"apiVersion":"v1","data":{"tls.crt":"LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQ0lqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FnOEFNSUlDQ2dLQ0FnRUFzYXlMb1ZBcFhhc05jbVIwNmJmeQpKc0VPTWt0ZFRXc0toelVGZUxYV0tlT09SYzIvaExtNnpVVGRWUExXbkNvL3o2SEhqdXN1YWdzaHdlNlBPZnRCCjY5eEVHWmxzdFowMGRvMkk5b2lleTNXTlRkOUhjdGFXbEVRZFRsYWpxaVZ4UmR4dnEyZUtUNk1Ga1ZUd1N6RG8KM0t5VUdhazhzWVVZaUlQV3NKMWFhRklsR1ZvRGx0UHcxcThaQXpUMmJmQXA2bzZGYk03aitiQ0FiQTdRTlJBTQpEVUxvL2xRaVVKNHluVlpaNm9tbkp1TlBLeHNUSExSRHBrZndVditNZ21WbVREa0xUK1d2VjZ3bmlRaDRqemh5CnZ4Y3dENStDeHpqUWNYc01kTEUvcE0zYzY0RWNPWEJ3WVlnbXFzSjhrMjRhN3c4MU9rVXNCQmdVaERtOER2TFAKanNqVTJGOVdjWm9UN040T000a0RCMkFBZHIyNXhMbEtaTDl6dlpXMnF2VDYyVzRGYW5qeVdRMmU5ZGk2QVU2bQovdk4ra2xHMVV5MEJqSXN3ZTdkdEMwK1Jod2Y0ZkVLeW00bHlnOGV4eWhQVEJQWHYxa3dERnd3eitPMFdWcG02CmlKcWFFVVlTL2hqcndtZzJWTitLR3FYRGRwWXo0RGlWM0hYOGRPa3IyRWVSVUNzdUpleElmSEZuYndNYzZRalkKSldxWTB0YUdmNm8zK1IyZjU0Nko4bThpaHlWNDlHU0ZyMGlXd01paUxHNTJBQmVVZ2tyVjlzR2dnS1FnaDUzcgozYjE3Ny9ZMVpDQ2xsSDVVWHJESG1aSDJQNnh5MUtad1lzUjlrNGUrZXZieDdoNzFESlV3VjlITUthbCtBWTZjCjMxRmNhSHBHQ1JhVHlFb05HY1lUckxFQ0F3RUFBUT09Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo="},"kind":"Secret","metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQ0lqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FnOEFNSUlDQ2dLQ0FnRUFzYXlMb1ZBcFhhc05jbVIwNmJmeQpKc0VPTWt0ZFRXc0toelVGZUxYV0tlT09SYzIvaExtNnpVVGRWUExXbkNvL3o2SEhqdXN1YWdzaHdlNlBPZnRCCjY5eEVHWmxzdFowMGRvMkk5b2lleTNXTlRkOUhjdGFXbEVRZFRsYWpxaVZ4UmR4dnEyZUtUNk1Ga1ZUd1N6RG8KM0t5VUdhazhzWVVZaUlQV3NKMWFhRklsR1ZvRGx0UHcxcThaQXpUMmJmQXA2bzZGYk03aitiQ0FiQTdRTlJBTQpEVUxvL2xRaVVKNHluVlpaNm9tbkp1TlBLeHNUSExSRHBrZndVditNZ21WbVREa0xUK1d2VjZ3bmlRaDRqemh5CnZ4Y3dENStDeHpqUWNYc01kTEUvcE0zYzY0RWNPWEJ3WVlnbXFzSjhrMjRhN3c4MU9rVXNCQmdVaERtOER2TFAKanNqVTJGOVdjWm9UN040T000a0RCMkFBZHIyNXhMbEtaTDl6dlpXMnF2VDYyVzRGYW5qeVdRMmU5ZGk2QVU2bQovdk4ra2xHMVV5MEJqSXN3ZTdkdEMwK1Jod2Y0ZkVLeW00bHlnOGV4eWhQVEJQWHYxa3dERnd3eitPMFdWcG02CmlKcWFFVVlTL2hqcndtZzJWTitLR3FYRGRwWXo0RGlWM0hYOGRPa3IyRWVSVUNzdUpleElmSEZuYndNYzZRalkKSldxWTB0YUdmNm8zK1IyZjU0Nko4bThpaHlWNDlHU0ZyMGlXd01paUxHNTJBQmVVZ2tyVjlzR2dnS1FnaDUzcgozYjE3Ny9ZMVpDQ2xsSDVVWHJESG1aSDJQNnh5MUtad1lzUjlrNGUrZXZieDdoNzFESlV3VjlITUthbCtBWTZjCjMxRmNhSHBHQ1JhVHlFb05HY1lUckxFQ0F3RUFBUT09Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=\"},\"kind\":\"Secret\",\"metadata\":{\"name\":\"cert-token-signing-gateway-pub\",\"namespace\":\"upbound-system\"}}"},"creationTimestamp":"2022-09-13T17:11:36Z","managedFields":[{"apiVersion":"v1","fieldsType":"FieldsV1","fieldsV1":{"f:data":{".":{},"f:tls.crt":{}},"f:metadata":{"f:annotations":{".":{},"f:kubectl.kubernetes.io/last-applied-configuration":{}}},"f:type":{}},"manager":"crossplane-kubernetes-provider","operation":"Update","time":"2022-09-13T17:11:36Z"}],"name":"cert-token-signing-gateway-pub","namespace":"upbound-system","resourceVersion":"358","uid":"94472dde-375a-4439-8541-327f8f60fbf3"},"type":"Opaque"}}}}}
2022-09-13T17:16:21.673Z	DEBUG	provider-kubernetes	Successfully requested deletion of external resource	{"controller": "managed/object.kubernetes.crossplane.io", "request": "/e05b83e7-21b1-4484-b0bb-68de83724d68-zb5bm", "uid": "6bd0201c-5b61-4e66-a461-43d22797d6ec", "version": "252208", "external-name": "e05b83e7-21b1-4484-b0bb-68de83724d68-zb5bm", "deletion-timestamp": "2022-09-13 17:16:20 +0000 UTC"}
2022-09-13T17:16:22.530Z	DEBUG	provider-kubernetes	Cannot remove managed resource finalizer	{"controller": "managed/object.kubernetes.crossplane.io", "request": "/e05b83e7-21b1-4484-b0bb-68de83724d68-zb5bm", "uid": "6bd0201c-5b61-4e66-a461-43d22797d6ec", "version": "252238", "external-name": "e05b83e7-21b1-4484-b0bb-68de83724d68-zb5bm", "deletion-timestamp": "2022-09-13 17:16:20 +0000 UTC", "error": "cannot remove finalizer from Object: cannot remove finalizer from referenced resource: Operation cannot be fulfilled on kubecontrolplanes.mcp.upbound.io \"e05b83e7-21b1-4484-b0bb-68de83724d68\": the object has been modified; please apply your changes to the latest version and try again", "errorVerbose": "Operation cannot be fulfilled on kubecontrolplanes.mcp.upbound.io \"e05b83e7-21b1-4484-b0bb-68de83724d68\": the object has been modified; please apply your changes to the latest version and try again\ncannot remove finalizer from referenced resource\ngithub.com/crossplane-contrib/provider-kubernetes/internal/controller/object.(*objFinalizer).RemoveFinalizer.func1\n\t/home/runner/work/provider-kubernetes/provider-kubernetes/internal/controller/object/object.go:552\ngithub.com/crossplane-contrib/provider-kubernetes/internal/controller/object.(*objFinalizer).handleRefFinalizer\n\t/home/runner/work/provider-kubernetes/provider-kubernetes/internal/controller/object/object.go:491\ngithub.com/crossplane-contrib/provider-kubernetes/internal/controller/object.(*objFinalizer).RemoveFinalizer\n\t/home/runner/work/provider-kubernetes/provider-kubernetes/internal/controller/object/object.go:547\ngithub.com/crossplane/crossplane-runtime/pkg/reconciler/managed.(*Reconciler).Reconcile\n\t/home/runner/work/provider-kubernetes/provider-kubernetes/vendor/github.com/crossplane/crossplane-runtime/pkg/reconciler/managed/reconciler.go:833\ngithub.com/crossplane/crossplane-runtime/pkg/ratelimiter.(*Reconciler).Reconcile\n\t/home/runner/work/provider-kubernetes/provider-kubernetes/vendor/github.com/crossplane/crossplane-runtime/pkg/ratelimiter/reconciler.go:54\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/home/runner/work/provider-kubernetes/provider-kubernetes/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/runner/work/provider-kubernetes/provider-kubernetes/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/runner/work/provider-kubernetes/provider-kubernetes/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/home/runner/work/provider-kubernetes/provider-kubernetes/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227\nruntime.goexit\n\t/opt/hostedtoolcache/go/1.17.12/x64/src/runtime/asm_arm64.s:1133\ncannot remove finalizer from Object\ngithub.com/crossplane-contrib/provider-kubernetes/internal/controller/object.(*objFinalizer).RemoveFinalizer\n\t/home/runner/work/provider-kubernetes/provider-kubernetes/internal/controller/object/object.go:557\ngithub.com/crossplane/crossplane-runtime/pkg/reconciler/managed.(*Reconciler).Reconcile\n\t/home/runner/work/provider-kubernetes/provider-kubernetes/vendor/github.com/crossplane/crossplane-runtime/pkg/reconciler/managed/reconciler.go:833\ngithub.com/crossplane/crossplane-runtime/pkg/ratelimiter.(*Reconciler).Reconcile\n\t/home/runner/work/provider-kubernetes/provider-kubernetes/vendor/github.com/crossplane/crossplane-runtime/pkg/ratelimiter/reconciler.go:54\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/home/runner/work/provider-kubernetes/provider-kubernetes/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/runner/work/provider-kubernetes/provider-kubernetes/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/runner/work/provider-kubernetes/provider-kubernetes/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/home/runner/work/provider-kubernetes/provider-kubernetes/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227\nruntime.goexit\n\t/opt/hostedtoolcache/go/1.17.12/x64/src/runtime/asm_arm64.s:1133"}
2022-09-13T17:16:22.532Z	ERROR	controller.managed/object.kubernetes.crossplane.io	Reconciler error	{"reconciler group": "kubernetes.crossplane.io", "reconciler kind": "Object", "name": "e05b83e7-21b1-4484-b0bb-68de83724d68-zb5bm", "namespace": "", "error": "cannot update managed resource status: Operation cannot be fulfilled on objects.kubernetes.crossplane.io \"e05b83e7-21b1-4484-b0bb-68de83724d68-zb5bm\": StorageError: invalid object, Code: 4, Key: /registry/kubernetes.crossplane.io/objects/e05b83e7-21b1-4484-b0bb-68de83724d68-zb5bm, ResourceVersion: 0, AdditionalErrorMsg: Precondition failed: UID in precondition: 6bd0201c-5b61-4e66-a461-43d22797d6ec, UID in object meta: "}
```

This PR fixes the condition by adjusting reconciliation of a deleted `Object` to first remove reference finalizers before removing the `Object` finalizer. This ensures that the `Object` isn't cleaned up until all reference finalizers are removed.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I reproduced the bug using provider-kubernetes v0.4.0, and verified that it could not be reproduced after many attempts using [a version of this branch based on tag v0.4.0](https://github.com/branden/crossplane-provider-kubernetes/tree/ref-finalizer-race-v0.4.0).

[contribution process]: https://git.io/fj2m9
