### PR TITLE
GKE Default Credentials and Temporary Access Tokens

### DIFF
--- a/internal/clients/gke/gke.go
+++ b/internal/clients/gke/gke.go
@@ -49,6 +49,9 @@ func WrapRESTConfig(ctx context.Context, rc *rest.Config, credentials []byte, sc
 			t := oauth2.Token{
 				AccessToken: string(credentials),
 			}
+			if ok := t.Valid(); !ok {
+				return errors.New("Access token invalid")
+			}
 			ts = oauth2.StaticTokenSource(&t)
 		}
 	} else {

--- a/internal/clients/gke/gke.go
+++ b/internal/clients/gke/gke.go
@@ -16,6 +16,7 @@ package gke
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -33,15 +34,42 @@ var DefaultScopes []string = []string{
 // WrapRESTConfig configures the supplied REST config to use OAuth2 bearer
 // tokens fetched using the supplied Google Application Credentials.
 func WrapRESTConfig(ctx context.Context, rc *rest.Config, credentials []byte, scopes ...string) error {
-	creds, err := google.CredentialsFromJSON(ctx, credentials, scopes...)
-	if err != nil {
-		return errors.Wrap(err, "cannot load Google Application Credentials from JSON")
+	var ts oauth2.TokenSource
+	if credentials != nil {
+		if isJSON(credentials) {
+			// If credentials are in a JSON format, extract the credential from the JSON
+			// CredentialsFromJSON creates a TokenSource that handles token caching.
+			creds, err := google.CredentialsFromJSON(ctx, credentials, scopes...)
+			if err != nil {
+				return errors.Wrap(err, "cannot load Google Application Credentials from JSON")
+			}
+			ts = creds.TokenSource
+		} else {
+			// if the credential not in a JSON format, treat the credential as an access token
+			t := oauth2.Token{
+				AccessToken: string(credentials),
+			}
+			ts = oauth2.StaticTokenSource(&t)
+		}
+	} else {
+		var t *oauth2.Token
+		// DefaultTokenSource retrieves a token source from an injected identity.
+		gsrc, err := google.DefaultTokenSource(ctx, scopes...)
+		if err != nil {
+			return errors.Wrap(err, "failed to extract default credentials source")
+		}
+		ts = oauth2.ReuseTokenSource(t, gsrc)
 	}
 
 	// CredentialsFromJSON creates a TokenSource that handles token caching.
 	rc.Wrap(func(rt http.RoundTripper) http.RoundTripper {
-		return &oauth2.Transport{Source: creds.TokenSource, Base: rt}
+		return &oauth2.Transport{Source: ts, Base: rt}
 	})
 
 	return nil
+}
+
+func isJSON(b []byte) bool {
+	var js json.RawMessage
+	return json.Unmarshal(b, &js) == nil
 }


### PR DESCRIPTION
Signed-off-by: Brad Wadsworth <brad.wadsworth@mavenwave.com>

### Description of your changes

This change will allow InjectedIdentity via GKE workload identity to be used in order to authenticate to a GKE cluster. Moreover, in addition to service account keys being used as secrets, temporary access tokens may also be used. The access tokens may be created from a CronJob that regenerates the token every hour. 
Fixes #36

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Tested in a GKE cluster in order to verify workload identity.
