### PR TITLE
Fix removing finalizers when referenced resources are gone

### DIFF
--- a/internal/controller/object/object_test.go
+++ b/internal/controller/object/object_test.go
@@ -1337,6 +1337,25 @@ func Test_objFinalizer_RemoveFinalizer(t *testing.T) {
 				finalizers: []string{},
 			},
 		},
+		"ReferenceNotFound": {
+			args: args{
+				mg: kubernetesObject(func(obj *v1alpha1.Object) {
+					obj.ObjectMeta.Finalizers = append(obj.ObjectMeta.Finalizers, objFinalizerName)
+					obj.Spec.References = objectReferences()
+					obj.ObjectMeta.UID = "some-uid"
+				}),
+				client: resource.ClientApplicator{
+					Client: &test.MockClient{
+						MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, testReferenceObjectName)),
+						MockUpdate: test.NewMockUpdateFn(nil),
+					},
+				},
+			},
+			want: want{
+				err:        nil,
+				finalizers: []string{},
+			},
+		},
 		"FailedToRemoveReferenceFinalizer": {
 			args: args{
 				mg: kubernetesObject(func(obj *v1alpha1.Object) {


### PR DESCRIPTION
Signed-off-by: Bartosz Slawianowski <bartosz.slawianowski@natzka.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Recently we encountered issue where sometimes a referenced object (Secret holding connection details) gets removed before the `kubernetes-provider` has a chance to remove its finalizer. This results in `Object` not being able to finish deletion process.

This PR makes it so referenced objects that no longer exist are skipped when removing finalizers. 

Let me know if you think that's not a correct approach.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested on local K8s cluster by deleting `Object` after manually deleting referenced resource.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
