### PR TITLE
Update output columns

### DIFF
--- a/apis/object/v1alpha1/types.go
+++ b/apis/object/v1alpha1/types.go
@@ -132,6 +132,11 @@ type ObjectStatus struct {
 
 // A Object is an provider Kubernetes API type
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="KIND",type="string",JSONPath=".spec.forProvider.manifest.kind"
+// +kubebuilder:printcolumn:name="APIVERSION",type="string",JSONPath=".spec.forProvider.manifest.apiVersion",priority=1
+// +kubebuilder:printcolumn:name="METANAME",type="string",JSONPath=".spec.forProvider.manifest.metadata.name",priority=1
+// +kubebuilder:printcolumn:name="METANAMESPACE",type="string",JSONPath=".spec.forProvider.manifest.metadata.namespace",priority=1
+// +kubebuilder:printcolumn:name="PROVIDERCONFIG",type="string",JSONPath=".spec.providerConfigRef.name"
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"

--- a/package/crds/kubernetes.crossplane.io_objects.yaml
+++ b/package/crds/kubernetes.crossplane.io_objects.yaml
@@ -20,6 +20,24 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .spec.forProvider.manifest.kind
+      name: KIND
+      type: string
+    - jsonPath: .spec.forProvider.manifest.apiVersion
+      name: APIVERSION
+      priority: 1
+      type: string
+    - jsonPath: .spec.forProvider.manifest.metadata.name
+      name: METANAME
+      priority: 1
+      type: string
+    - jsonPath: .spec.forProvider.manifest.metadata.namespace
+      name: METANAMESPACE
+      priority: 1
+      type: string
+    - jsonPath: .spec.providerConfigRef.name
+      name: PROVIDERCONFIG
+      type: string
     - jsonPath: .status.conditions[?(@.type=='Synced')].status
       name: SYNCED
       type: string


### PR DESCRIPTION
### Description of your changes

Added KIND and PROVIDERCONFIG columns to standard output column list

Added "METANAME", "METANAMESPACE" and "APIVERSION" columns to the wide output column list.

Fixes #78 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Tested in a local dev cluster:

```
$ kubectl get objects
NAME                   KIND                             PROVIDERCONFIG         SYNCED   READY   AGE
atsg0-4bmfh            ProviderConfig                   atsg0-tdg6b            True     True    11d
atsg0-4l9np            ControllerConfig                 atsg0-tdg6b            True     True    11d
atsg0-4zbmn            ConfigMap                        atsg0-tdg6b            True     True    11d
atsg0-52nhs            Secret                           atsg0-tdg6b            True     True    11d
atsg0-52tpv            Namespace                        atsg0-tdg6b            True     True    2d10h
```

```
$ kubectl get objects -o wide
NAME                   KIND                             APIVERSION                                   METANAME                                                          METANAMESPACE       PROVIDERCONFIG         SYNCED   READY   AGE
atsg0-4bmfh            ProviderConfig                   aws.crossplane.io/v1beta1                    578356578901                                                                          atsg0-tdg6b            True     True    11d
atsg0-4l9np            ControllerConfig                 pkg.crossplane.io/v1alpha1                   terraform                                                                             atsg0-tdg6b            True     True    11d
atsg0-4zbmn            ConfigMap                        v1                                           additional-config-configmap                                       confg               atsg0-tdg6b            True     True    11d
atsg0-52nhs            Secret                           v1                                           provider-jet-atsg0-cpq5z                                          crossplane-system   atsg0-tdg6b            True     True    11d
atsg0-52tpv            Namespace                        v1                                           mynamespc                                                                             atsg0-tdg6b            True     True    2d10h
```


[contribution process]: https://git.io/fj2m9
