### PR TITLE
Configure higher burst and QPS to avoid client side throttling

### DIFF
--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -57,7 +57,7 @@ func restConfigFromAPIConfig(c *api.Config) (*rest.Config, error) {
 		// set of identity credentials (e.g. Google Application Creds).
 		user = &api.AuthInfo{}
 	}
-	return &rest.Config{
+	config := &rest.Config{
 		Host:            cluster.Server,
 		Username:        user.Username,
 		Password:        user.Password,
@@ -77,5 +77,12 @@ func restConfigFromAPIConfig(c *api.Config) (*rest.Config, error) {
 			KeyData:    user.ClientKeyData,
 			CAData:     cluster.CertificateAuthorityData,
 		},
-	}, nil
+	}
+
+	// NOTE(tnthornton): these values match the burst and QPS values in kubectl.
+	// xref: https://github.com/kubernetes/kubernetes/pull/105520
+	config.Burst = 300
+	config.QPS = 50
+
+	return config, nil
 }


### PR DESCRIPTION
### Description of your changes
Sets `Burst` and `QPS` to values in:
* [kubectl](https://github.com/kubernetes/kubernetes/pull/109141)
* [up](https://github.com/upbound/up/blob/d38751eccb0dcd30dec2a3b7f54521b50e29e913/internal/install/helm/restclientgetter.go#L52)

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
1. `make build`
2. deployed the new provider image into an environment that had Crossplane + upbound/provider-aws running and was experiencing client-side throttling errors.
3. verified after the image was deployed that the client-side throttling errors went away.

[contribution process]: https://git.io/fj2m9
