### PR TITLE
Fix Makefile default target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,20 @@ IMAGES = provider-kubernetes
 -include build/makelib/imagelight.mk
 
 # ====================================================================================
+# Targets
+
+# run `make help` to see the targets and options
+
+# We want submodules to be set up the first time `make` is run.
+# We manage the build/ folder and its Makefiles as a submodule.
+# The first time `make` is run, the includes of build/*.mk files will
+# all fail, and this target will be run. The next time, the default as defined
+# by the includes will be run instead.
+fallthrough: submodules
+	@echo Initial setup complete. Running make again . . .
+	@make
+
+# ====================================================================================
 # Setup XPKG
 
 XPKG_REG_ORGS ?= xpkg.upbound.io/crossplane-contrib index.docker.io/crossplanecontrib
@@ -63,20 +77,6 @@ xpkg.build.provider-kubernetes: do.build.images
 # ====================================================================================
 # Setup Local Dev
 -include build/makelib/local.mk
-
-# ====================================================================================
-# Targets
-
-# run `make help` to see the targets and options
-
-# We want submodules to be set up the first time `make` is run.
-# We manage the build/ folder and its Makefiles as a submodule.
-# The first time `make` is run, the includes of build/*.mk files will
-# all fail, and this target will be run. The next time, the default as defined
-# by the includes will be run instead.
-fallthrough: submodules
-	@echo Initial setup complete. Running make again . . .
-	@make
 
 # Generate a coverage report for cobertura applying exclusions on
 # - generated file


### PR DESCRIPTION
### Description of your changes
Fix Makefile default target so `make` runs successfully on a freshly cloned repository.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Verified that `make` command runs successfully on a freshly cloned repository.

[contribution process]: https://git.io/fj2m9
