### PR TITLE
cleanerr: Clean errors for stable status

### DIFF
--- a/internal/controller/object/cleanerr.go
+++ b/internal/controller/object/cleanerr.go
@@ -1,0 +1,37 @@
+package object
+
+import "regexp"
+
+// CleanErr masks pointers in err when printing the message.
+// errors.As and errors.Is can still find the original error.
+// If err is nil, CleanErr returns nil.
+func CleanErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &cleanedError{cause: err}
+}
+
+type cleanedError struct {
+	cause error
+}
+
+func (w *cleanedError) Error() string { return cleanErrorMessage(w.cause) }
+func (w *cleanedError) Cause() error  { return w.cause }
+
+// Unwrap provides compatibility for Go 1.13 error chains.
+func (w *cleanedError) Unwrap() error { return w.cause }
+
+var pointerRegex = regexp.MustCompile(`\(0x[0-9a-f]{5,}\)`)
+
+// cleanErrorMessage returns the error reproducible error message for kubernetes errors by removing any pointers in the message.
+//
+// Given
+//
+//	cannot patch object: Job.batch "pi-1" is invalid: spec.template: Invalid value: core.PodTemplateSpec{... TerminationGracePeriodSeconds:(*int64)(0x4012805d98)...: field is immutable
+//
+// the pointer will be masked: TerminationGracePeriodSeconds:(*int64)(..ptr..)
+func cleanErrorMessage(err error) string {
+	oldString := err.Error()
+	return pointerRegex.ReplaceAllString(oldString, "(..ptr..)")
+}

--- a/internal/controller/object/cleanerr_test.go
+++ b/internal/controller/object/cleanerr_test.go
@@ -1,0 +1,65 @@
+package object
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCleanWrap(t *testing.T) {
+	const (
+		messageWithoutPointer    = "this is 0123abc a normal error message (yeah)"
+		messageWithPointer       = "cannot patch object: Job.batch 'pi-1' is invalid: spec.template: Invalid value: core.PodTemplateSpec{... TerminationGracePeriodSeconds:(*int64)(0x4012805d98): field is immutable"
+		messageWithPointerMasked = "cannot patch object: Job.batch 'pi-1' is invalid: spec.template: Invalid value: core.PodTemplateSpec{... TerminationGracePeriodSeconds:(*int64)(..ptr..): field is immutable"
+	)
+	tests := []struct {
+		name string
+		in   error
+
+		check func(t *testing.T, err error)
+	}{
+		{
+			name: "nil is nil",
+			in:   nil,
+			check: func(t *testing.T, err error) {
+				if err != nil {
+					t.Errorf("expected nil error, got %+v", err)
+				}
+			},
+		},
+		{
+			name: "normal error preserved",
+			in:   errors.New(messageWithoutPointer),
+			check: func(t *testing.T, err error) {
+				if err.Error() != messageWithoutPointer {
+					t.Errorf("expected %q error, got %v", messageWithoutPointer, err.Error())
+				}
+			},
+		},
+		{
+			name: "pointer is masked",
+			in:   errors.New(messageWithPointer),
+			check: func(t *testing.T, err error) {
+				if err.Error() != messageWithPointerMasked {
+					t.Errorf("expected %q error, got %v", messageWithPointerMasked, err.Error())
+				}
+			},
+		},
+		{
+			name: "errors.As preseved and kubernetes compatibility",
+			in:   &kerrors.StatusError{ErrStatus: v1.Status{Reason: v1.StatusReasonAlreadyExists}},
+			check: func(t *testing.T, err error) {
+				if !kerrors.IsAlreadyExists(err) {
+					t.Error("expected kerrors.IsAlreadyExists, got false")
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.check(t, CleanErr(tt.in))
+		})
+	}
+}

--- a/internal/controller/object/object.go
+++ b/internal/controller/object/object.go
@@ -296,7 +296,7 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	})
 
 	if err := c.client.Apply(ctx, obj); err != nil {
-		return managed.ExternalUpdate{}, errors.Wrap(err, errApplyObject)
+		return managed.ExternalUpdate{}, errors.Wrap(CleanErr(err), errApplyObject)
 	}
 
 	return managed.ExternalUpdate{}, c.setObserved(cr, obj)


### PR DESCRIPTION
### Description of your changes

Some error messages from the kubernetes API contain formatted pointers. This
triggers an infinite loop in provider-kubernetes, as each attempt to reconcile
updates the status with a new error message.

To avoid this loop, mask pointer references in errors on update.

A similar fix exists in provider-aws.

Without this change, we can see a lot of reconciles for one object over a short
time period:

  Warning  CannotUpdateExternalResource  3m38s (x849 over 8m39s)  managed/object.kubernetes.crossplane.io  (combined from similar events):

This might also block other resources from reconciling.

For consideration: It may be that PR https://github.com/crossplane-contrib/provider-kubernetes/pull/110 effectively fixes _most_ of the issue covered here. Events produced would still be duplicated, but the reconcile spinning would likely stop.


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

* Ran provider-kubernetes locally, created Job objects and modified them.
* Added new unit tests for this function.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
