### PR TITLE
Add an `AllTrue` readiness policy

### DIFF
--- a/apis/object/v1alpha1/types.go
+++ b/apis/object/v1alpha1/types.go
@@ -136,6 +136,10 @@ const (
 	// ReadinessPolicyDeriveFromObject means the object is marked as ready if and only if the underlying
 	// external resource is considered ready.
 	ReadinessPolicyDeriveFromObject ReadinessPolicy = "DeriveFromObject"
+
+	// ReadinessPolicyAllTrue means that all conditions have status true on the object.
+	// There must be at least one condition.
+	ReadinessPolicyAllTrue ReadinessPolicy = "AllTrue"
 )
 
 // Readiness defines how the object's readiness condition should be computed,
@@ -144,7 +148,7 @@ const (
 type Readiness struct {
 	// Policy defines how the Object's readiness condition should be computed.
 	// +optional
-	// +kubebuilder:validation:Enum=SuccessfulCreate;DeriveFromObject
+	// +kubebuilder:validation:Enum=SuccessfulCreate;DeriveFromObject;AllTrue
 	// +kubebuilder:default=SuccessfulCreate
 	Policy ReadinessPolicy `json:"policy,omitempty"`
 }

--- a/package/crds/kubernetes.crossplane.io_objects.yaml
+++ b/package/crds/kubernetes.crossplane.io_objects.yaml
@@ -304,6 +304,7 @@ spec:
                     enum:
                     - SuccessfulCreate
                     - DeriveFromObject
+                    - AllTrue
                     type: string
                 type: object
               references:


### PR DESCRIPTION
This checks that all conditions are true, and if so marks the object as ready.


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #124

I have:

- [ x] Read and followed Crossplane's [contribution process].
- [ x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Unit tested and deployed locally and verified that deployment objects are marked appropriately when healthy/unhealthy.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
