### PR TITLE
Handle empty converts

### DIFF
--- a/apis/object/v1alpha1/conversion.go
+++ b/apis/object/v1alpha1/conversion.go
@@ -195,8 +195,9 @@ func (dst *Object) ConvertFrom(srcRaw conversion.Hub) error { // nolint:golint, 
 		!policySet.HasAny(xpv1.ManagementActionCreate, xpv1.ManagementActionUpdate, xpv1.ManagementActionDelete):
 		dst.Spec.ManagementPolicy = Observe
 	default:
-		// TODO(turkenh): Should we default to something here instead of erroring out?
-		return fmt.Errorf("unsupported management policies: %v", policySet.UnsortedList())
+		// NOTE(lsviben): Other combinations of v1alpha2 management policies
+		// were not supported in v1alpha1. Leaving it empty to avoid
+		// errors during conversion instead of failing.
 	}
 
 	return nil

--- a/apis/object/v1alpha1/conversion.go
+++ b/apis/object/v1alpha1/conversion.go
@@ -17,12 +17,11 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
 	"github.com/crossplane-contrib/provider-kubernetes/apis/object/v1alpha2"
 )
@@ -101,7 +100,7 @@ func (src *Object) ConvertTo(dstRaw conversion.Hub) error { // nolint:golint // 
 	case Observe:
 		dst.Spec.ManagementPolicies = xpv1.ManagementPolicies{xpv1.ManagementActionObserve}
 	default:
-		return fmt.Errorf("unknown management policy: %v", src.Spec.ManagementPolicy)
+		return errors.Errorf("unknown management policy: %v", src.Spec.ManagementPolicy)
 	}
 
 	return nil

--- a/apis/object/v1alpha1/conversion_test.go
+++ b/apis/object/v1alpha1/conversion_test.go
@@ -244,6 +244,7 @@ func TestConvertTo(t *testing.T) {
 				},
 			},
 		},
+
 		{
 			name: "errors if management policy is unknown",
 			args: args{
@@ -293,7 +294,7 @@ func TestConvertFrom(t *testing.T) {
 		want want
 	}{
 		{
-			name: "converts to v1alpha2",
+			name: "converts to v1alpha1",
 			args: args{
 				src: &v1alpha2.Object{
 					ObjectMeta: metav1.ObjectMeta{
@@ -386,7 +387,7 @@ func TestConvertFrom(t *testing.T) {
 			},
 		},
 		{
-			name: "converts to v1alpha2 - nil checks",
+			name: "converts to v1alpha1 - nil checks",
 			args: args{
 				src: &v1alpha2.Object{
 					ObjectMeta: metav1.ObjectMeta{
@@ -448,6 +449,42 @@ func TestConvertFrom(t *testing.T) {
 							},
 						},
 						Readiness: v1alpha1.Readiness{Policy: v1alpha1.ReadinessPolicySuccessfulCreate},
+					},
+				},
+			},
+		},
+		{
+			name: "converts to v1alpha1 - empty policy",
+			args: args{
+				src: &v1alpha2.Object{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "coolobject",
+					},
+					Spec: v1alpha2.ObjectSpec{
+						ResourceSpec: v1.ResourceSpec{
+							DeletionPolicy: v1.DeletionDelete,
+						},
+						ForProvider: v1alpha2.ObjectParameters{
+							Manifest: runtime.RawExtension{Raw: []byte("apiVersion: v1\nkind: Secret\nmetadata:\n  name: topsecret\n")},
+						},
+					},
+				},
+			},
+			want: want{
+				dst: &v1alpha1.Object{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "coolobject",
+					},
+					Spec: v1alpha1.ObjectSpec{
+						ResourceSpec: v1alpha1.ResourceSpec{
+							DeletionPolicy: v1.DeletionDelete,
+						},
+						ForProvider: v1alpha1.ObjectParameters{
+							Manifest: runtime.RawExtension{Raw: []byte("apiVersion: v1\nkind: Secret\nmetadata:\n  name: topsecret\n")},
+						},
+						ManagementPolicy:  v1alpha1.Default,
+						ConnectionDetails: []v1alpha1.ConnectionDetail{},
+						References:        []v1alpha1.Reference{},
 					},
 				},
 			},

--- a/apis/object/v1alpha1/conversion_test.go
+++ b/apis/object/v1alpha1/conversion_test.go
@@ -244,7 +244,6 @@ func TestConvertTo(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			name: "errors if management policy is unknown",
 			args: args{
@@ -258,7 +257,7 @@ func TestConvertTo(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.New("unknown management policy"),
+				err: errors.New("unknown management policy: unknown"),
 			},
 		},
 	}
@@ -490,7 +489,7 @@ func TestConvertFrom(t *testing.T) {
 			},
 		},
 		{
-			name: "errors if management policy is unknown",
+			name: "converts to v1alpha1 - unsupported policy",
 			args: args{
 				src: &v1alpha2.Object{
 					ObjectMeta: metav1.ObjectMeta{
@@ -498,13 +497,32 @@ func TestConvertFrom(t *testing.T) {
 					},
 					Spec: v1alpha2.ObjectSpec{
 						ResourceSpec: v1.ResourceSpec{
-							ManagementPolicies: []v1.ManagementAction{},
+							DeletionPolicy:     v1.DeletionDelete,
+							ManagementPolicies: []v1.ManagementAction{v1.ManagementActionDelete},
+						},
+						ForProvider: v1alpha2.ObjectParameters{
+							Manifest: runtime.RawExtension{Raw: []byte("apiVersion: v1\nkind: Secret\nmetadata:\n  name: topsecret\n")},
 						},
 					},
 				},
 			},
 			want: want{
-				err: errors.New("unsupported management policy"),
+				dst: &v1alpha1.Object{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "coolobject",
+					},
+					Spec: v1alpha1.ObjectSpec{
+						ResourceSpec: v1alpha1.ResourceSpec{
+							DeletionPolicy: v1.DeletionDelete,
+						},
+						ForProvider: v1alpha1.ObjectParameters{
+							Manifest: runtime.RawExtension{Raw: []byte("apiVersion: v1\nkind: Secret\nmetadata:\n  name: topsecret\n")},
+						},
+						ManagementPolicy:  "",
+						ConnectionDetails: []v1alpha1.ConnectionDetail{},
+						References:        []v1alpha1.Reference{},
+					},
+				},
 			},
 		},
 	}

--- a/examples/in-composition/composition.yaml
+++ b/examples/in-composition/composition.yaml
@@ -206,7 +206,7 @@ spec:
       readinessChecks:
         - type: None
     - base:
-        apiVersion: kubernetes.crossplane.io/v1beta1
+        apiVersion: kubernetes.crossplane.io/v1alpha2
         kind: Object
         spec:
           forProvider:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Fix for https://github.com/crossplane-contrib/provider-kubernetes/issues/179 . Handles the conversion case from `v1alpha2` to `v1alpha1` when the `spec.managementPolicies` are unset which was causing the issue.

This was happening when:
1. A resource existed in `v1alpha1` version
2. The provider was upgraded to v0.11.0 (`v1alpha2`)
3. The Composition was updated to use `v1alpha2`
4. The resource in the Composition does not have a `spec.managementPolices` set (relies on defaulting)

So what happened was that the `v1alpha2` Object, without the `spec.managementPolicies` was being converted to `v1alpha1` during the Composition reconciliation. This could be because it is updating the existing resource which is still stored in `v1alpha1` version, although after the first update, the resource should be stored in `v1alpha2` version as its the storage version, based on [docs](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#writing-reading-and-updating-versioned-customresourcedefinition-objects).

As the defaulting happens after conversion, the conversion fails. Now this is handled so that if the resource does not have a `spec.managementPolicies` set or a CreationTimestamp (this is to differentiate between converting resources paused through management policies and resources from Compositions), the `spec.managementPolicy` is set to `Default`.

Additionally, to avoid conversion errors, if the policy we are converting from `v1alpha2` to `v1alpha1` is unsupported, the `spec.managementPolicy` field is left empty. I was thinking either to leave it empty, which will default to Default if the resource is created, or set it to Observe to be safe, but decided on Default as it seems like the most fitting based on the other checks. If its not being created, it will be empty and users will need to manual set it. This was needed so that `v1alpha2` policies like `spec.managementPolicies: ["Observe", "Update"]` can be used in the above case as well. 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #179

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Was testing using the reproduction [setup](https://github.com/haarchri/issue-provider-kubernetes-conversion) for the #179 bug from @haarchri (thanks again for setting it up, really helpful!). 

The example from issue, using the setup.sh now passes. The resulting Object has `spec.managementPolicies: ["*"]`

Also tried with setting an unsupported policy in the Composition like `spec.managementPolicies: ["Observe", "Update"]` and that works as well. The resulting Object has `spec.managementPolicies: ["Observe", "Update"]`

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
