### PR TITLE
Add jitter to poll interval

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -72,6 +72,14 @@ func main() {
 		ctrl.SetLogger(zl)
 	}
 
+	// configure the jitter to be the 10% of the poll interval
+	pollJitter := time.Duration(float64(*pollInterval) * 0.1)
+	log.Debug("Starting",
+		"sync-interval", syncInterval.String(),
+		"poll-interval", pollInterval.String(),
+		"poll-jitter", pollJitter.String(),
+		"max-reconcile-rate", *maxReconcileRate)
+
 	cfg, err := ctrl.GetConfig()
 	kingpin.FatalIfError(err, "Cannot get API server rest config")
 
@@ -130,7 +138,7 @@ func main() {
 	// notice and remove when we drop support for v1alpha1.
 	kingpin.FatalIfError(ctrl.NewWebhookManagedBy(mgr).For(&v1alpha1.Object{}).Complete(), "Cannot create Object webhook")
 
-	kingpin.FatalIfError(object.Setup(mgr, o, *sanitizeSecrets), "Cannot setup controller")
+	kingpin.FatalIfError(object.Setup(mgr, o, *sanitizeSecrets, pollJitter), "Cannot setup controller")
 	kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
 }
 

--- a/internal/controller/kubernetes.go
+++ b/internal/controller/kubernetes.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"time"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
@@ -27,11 +29,11 @@ import (
 
 // Setup creates all Template controllers with the supplied logger and adds them to
 // the supplied manager.
-func Setup(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool) error {
+func Setup(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, pollJitter time.Duration) error {
 	if err := config.Setup(mgr, o); err != nil {
 		return err
 	}
-	if err := object.Setup(mgr, o, sanitizeSecrets); err != nil {
+	if err := object.Setup(mgr, o, sanitizeSecrets, pollJitter); err != nil {
 		return err
 	}
 	return nil

--- a/internal/controller/object/object.go
+++ b/internal/controller/object/object.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -91,7 +92,7 @@ const (
 )
 
 // Setup adds a controller that reconciles Object managed resources.
-func Setup(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool) error {
+func Setup(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, pollJitter time.Duration) error {
 	name := managed.ControllerName(v1alpha2.ObjectGroupKind)
 
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}
@@ -112,6 +113,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool) error {
 		}),
 		managed.WithFinalizer(&objFinalizer{client: mgr.GetClient()}),
 		managed.WithPollInterval(o.PollInterval),
+		managed.WithPollJitterHook(pollJitter),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithConnectionPublishers(cps...),


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

- Adds a +/-10% jitter to Object's reconcile delay, helps towards spreading out requeue'ing of resources and minimize the likelihood of running into K8s client qps/burst limits.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

- `make test` and `make e2e`

- below graph shows the before(blue plot) and after(green plot) effect of this change on reconciliation rate of Object resources running with poll-interval=5m and poll-jitter=30s:
<img width="1698" alt="Screenshot 2024-02-10 at 2 11 49 PM" src="https://github.com/crossplane-contrib/provider-kubernetes/assets/3928411/ceb4a736-fc49-4579-9766-16417e92e8de">


[contribution process]: https://git.io/fj2m9
