### PR TITLE
fix missing ToConnectionSecretKey in conversion

### DIFF
--- a/apis/object/v1alpha1/conversion.go
+++ b/apis/object/v1alpha1/conversion.go
@@ -43,7 +43,8 @@ func (src *Object) ConvertTo(dstRaw conversion.Hub) error { // nolint:golint // 
 	connectionDetails := []v1alpha2.ConnectionDetail{}
 	for _, cd := range src.Spec.ConnectionDetails {
 		connectionDetails = append(connectionDetails, v1alpha2.ConnectionDetail{
-			ObjectReference: cd.ObjectReference,
+			ObjectReference:       cd.ObjectReference,
+			ToConnectionSecretKey: cd.ToConnectionSecretKey,
 		})
 	}
 
@@ -123,7 +124,8 @@ func (dst *Object) ConvertFrom(srcRaw conversion.Hub) error { // nolint:golint, 
 	connectionDetails := []ConnectionDetail{}
 	for _, cd := range src.Spec.ConnectionDetails {
 		connectionDetails = append(connectionDetails, ConnectionDetail{
-			ObjectReference: cd.ObjectReference,
+			ObjectReference:       cd.ObjectReference,
+			ToConnectionSecretKey: cd.ToConnectionSecretKey,
 		})
 	}
 

--- a/apis/object/v1alpha1/conversion_test.go
+++ b/apis/object/v1alpha1/conversion_test.go
@@ -64,7 +64,9 @@ func TestConvertTo(t *testing.T) {
 									APIVersion: "v1",
 									Kind:       "Secret",
 									Name:       "topsecret",
+									FieldPath:  "data.token",
 								},
+								ToConnectionSecretKey: "token",
 							},
 						},
 						ForProvider: v1alpha1.ObjectParameters{
@@ -111,7 +113,9 @@ func TestConvertTo(t *testing.T) {
 									APIVersion: "v1",
 									Kind:       "Secret",
 									Name:       "topsecret",
+									FieldPath:  "data.token",
 								},
+								ToConnectionSecretKey: "token",
 							},
 						},
 						ForProvider: v1alpha2.ObjectParameters{
@@ -196,7 +200,9 @@ func TestConvertTo(t *testing.T) {
 									APIVersion: "v1",
 									Kind:       "Secret",
 									Name:       "topsecret",
+									FieldPath:  "data.token",
 								},
+								ToConnectionSecretKey: "token",
 							},
 						},
 						ForProvider: v1alpha1.ObjectParameters{
@@ -229,7 +235,9 @@ func TestConvertTo(t *testing.T) {
 									APIVersion: "v1",
 									Kind:       "Secret",
 									Name:       "topsecret",
+									FieldPath:  "data.token",
 								},
+								ToConnectionSecretKey: "token",
 							},
 						},
 						ForProvider: v1alpha2.ObjectParameters{
@@ -312,7 +320,9 @@ func TestConvertFrom(t *testing.T) {
 									APIVersion: "v1",
 									Kind:       "Secret",
 									Name:       "topsecret",
+									FieldPath:  "data.token",
 								},
+								ToConnectionSecretKey: "token",
 							},
 						},
 						ForProvider: v1alpha2.ObjectParameters{
@@ -357,7 +367,9 @@ func TestConvertFrom(t *testing.T) {
 									APIVersion: "v1",
 									Kind:       "Secret",
 									Name:       "topsecret",
+									FieldPath:  "data.token",
 								},
+								ToConnectionSecretKey: "token",
 							},
 						},
 						ForProvider: v1alpha1.ObjectParameters{
@@ -407,7 +419,9 @@ func TestConvertFrom(t *testing.T) {
 									APIVersion: "v1",
 									Kind:       "Secret",
 									Name:       "topsecret",
+									FieldPath:  "data.token",
 								},
+								ToConnectionSecretKey: "token",
 							},
 						},
 						ForProvider: v1alpha2.ObjectParameters{
@@ -438,7 +452,9 @@ func TestConvertFrom(t *testing.T) {
 									APIVersion: "v1",
 									Kind:       "Secret",
 									Name:       "topsecret",
+									FieldPath:  "data.token",
 								},
+								ToConnectionSecretKey: "token",
 							},
 						},
 						ForProvider: v1alpha1.ObjectParameters{

--- a/examples/object/deprecated/connection-details.yaml
+++ b/examples/object/deprecated/connection-details.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: default
+  name: test-sa
+---
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: test-sa
+spec:
+  connectionDetails:
+  - apiVersion: v1
+    fieldPath: data.token
+    kind: Secret
+    name: test-sa-token
+    namespace: default
+    toConnectionSecretKey: token
+  forProvider:
+    manifest:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        annotations:
+          kubernetes.io/service-account.name: test-sa
+        name: test-sa-token
+        namespace: default
+      type: kubernetes.io/service-account-token
+  providerConfigRef:
+    name: kubernetes-provider
+  writeConnectionSecretToRef:
+    name: test-sa-conn-out
+    namespace: default


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
- Updates https://github.com/crossplane-contrib/provider-kubernetes/pull/163
the conversion webhook added in above missed handling of `spec.connectionDetails[].toConnectionSecretKey` resulting in those fields getting dropped during conversion.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
- `make test` and  `make e2e`
- Also added an example deprecated v1alpha1.Object resource with `spec.connectionDetails` and tested locally that conversion is lossless.

[contribution process]: https://git.io/fj2m9
