### PR TITLE
Add lsviben and phisco to OWNERS.md

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -12,3 +12,5 @@ guidelines and responsibilities for the steering committee and maintainers.
 
 * Hasan Turken <hasan@upbound.io> ([turkenh](https://github.com/turkenh))
 * Mo Ying (William) <morningspace@yahoo.com> ([morningspace](https://github.com/morningspace))
+* Lovro Sviben <lovro.sviben@upbound.io> ([lsviben](https://github.com/lsviben))
+* Philippe Scorsolini <philippe.scorsolini@upbound.io> ([phisco](https://github.com/phisco))


### PR DESCRIPTION
### Description of your changes

This PR updates the OWNERS.md file to be aligned with current access permissions for this repository - they appear to have gotten out of sync.

This effectively is a formal addition then of @lsviben and @phisco as maintainers to this repository 🎉 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `make reviewable test` to ensure this PR is ready for review.~

### How has this code been tested

The rendered markdown page has been verified in my fork: https://github.com/jbw976/provider-kubernetes/blob/update-owners/OWNERS.md 

[contribution process]: https://git.io/fj2m9
