### PR TITLE
Use build module from crossplane/build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "build"]
 	path = build
-	url = https://github.com/upbound/build
+	url = https://github.com/crossplane/build

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ GOLANGCILINT_VERSION = 1.55.2
 # Setup Kubernetes tools
 KIND_VERSION = v0.22.0
 UP_VERSION = v0.28.0
-UPTEST_VERSION = v0.9.0
 UP_CHANNEL = stable
 USE_HELM3 = true
 -include build/makelib/k8s_tools.mk
@@ -85,6 +84,7 @@ cobertura:
 
 # ====================================================================================
 # End to End Testing
+CROSSPLANE_VERSION = 1.16.0
 CROSSPLANE_NAMESPACE = crossplane-system
 -include build/makelib/local.xpkg.mk
 -include build/makelib/controlplane.mk


### PR DESCRIPTION
### Description of your changes

Use build submodule from github.com/crossplane/build given github.com/upbound/build is deprecated.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

CI

[contribution process]: https://git.io/fj2m9
