### PR TITLE
Support --build-arg from environment variables

### DIFF
--- a/cluster/images/provider-kubernetes/Makefile
+++ b/cluster/images/provider-kubernetes/Makefile
@@ -12,7 +12,7 @@ include ../../../build/makelib/imagelight.mk
 
 img.build:
 	@$(INFO) docker build $(IMAGE)
-	@$(MAKE) BUILD_ARGS="--load" img.build.shared
+	@$(MAKE) BUILD_ARGS="--load $(BUILD_ARGS)" img.build.shared
 	@$(OK) docker build $(IMAGE)
 
 img.publish:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Do not override additional `--build-arg`s for `docker buildx` from environment variables. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Local `make build` and inspection.

[contribution process]: https://git.io/fj2m9
