### PR TITLE
consume golangci-lint 1.61.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,14 @@
-run:
-  deadline: 2m
+# SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
 
-  skip-files:
-  - "zz_generated\\..+\\.go$"
+run:
+  timeout: 2m
 
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  format: colored-line-number
+  formats:
+    - format: colored-line-number
 
 linters-settings:
   errcheck:
@@ -18,18 +20,18 @@ linters-settings:
     # default is false: such cases aren't reported by default.
     check-blank: false
 
-    # [deprecated] comma-separated list of pairs of the form pkg:regex
-    # the regex is used to ignore names within pkg. (default "fmt:.*").
-    # see https://github.com/kisielk/errcheck#the-deprecated-method for details
-    ignore: fmt:.*,io/ioutil:^Read.*
+    exclude-functions:
+      - io/ioutil.ReadFile
+      - io/ioutil.ReadDir
+      - io/ioutil.ReadAll
 
   govet:
     # report about shadowed variables
     check-shadowing: false
 
-  golint:
-    # minimal confidence for issues, default is 0.8
-    min-confidence: 0.8
+  revive:
+    # confidence for issues, default is 0.8
+    confidence: 0.8
 
   gofmt:
     # simplify code: gofmt with `-s` option, true by default
@@ -49,10 +51,6 @@ linters-settings:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
     min-complexity: 10
 
-  maligned:
-    # print struct with more effective memory layout or not, false by default
-    suggest-new: true
-
   dupl:
     # tokens count to trigger issue, 150 by default
     threshold: 100
@@ -66,13 +64,6 @@ linters-settings:
   lll:
     # tab width in spaces. Default to 1.
     tab-width: 1
-
-  unused:
-    # treat code as a program (not a library) and report unused exported identifiers; default is false.
-    # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:
-    # if it's called for subdir of a project it can't find funcs usages. All text editor integrations
-    # with golangci-lint call it on a directory with the changed file.
-    check-exported: false
 
   unparam:
     # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
@@ -109,17 +100,18 @@ linters-settings:
 
 linters:
   enable:
-    - megacheck
     - govet
     - gocyclo
     - gocritic
-    - interfacer
     - goconst
     - gci
     - gofmt  # We enable this as well as goimports for its simplify mode.
+    - gosimple
     - prealloc
-    - golint
+    - revive
+    - staticcheck
     - unconvert
+    - unused
     - misspell
     - nakedret
 
@@ -128,8 +120,9 @@ linters:
     - unused
   fast: false
 
-
 issues:
+  exclude-files:
+    - "zz_generated\\..+\\.go$"
   # Excluding configuration per-path and per-linter
   exclude-rules:
     # Exclude some linters from running on tests files.
@@ -141,7 +134,7 @@ issues:
         - gosec
         - scopelint
         - unparam
-    
+
     # Ease some gocritic warnings on test files.
     - path: _test\.go
       text: "(unnamedResult|exitAfterDefer)"
@@ -194,7 +187,7 @@ issues:
   new: false
 
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
-  max-per-linter: 0
+  max-issues-per-linter: 0
 
   # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider
 GO_SUBDIRS += cmd internal apis pkg
 GO111MODULE = on
-GOLANGCILINT_VERSION = 1.55.2
+GOLANGCILINT_VERSION = 1.61.0
 -include build/makelib/golang.mk
 
 # ====================================================================================


### PR DESCRIPTION
### Description of your changes

Update crossplane/build to [d3155548bfab68fc8bea64c5526642b7b565ae33](https://github.com/crossplane/build/commit/d3155548bfab68fc8bea64c5526642b7b565ae33) which includes an update of `golangci-lint` to `1.61.0` to fix problems linting on macOS (arm64). See https://github.com/crossplane/build/pull/23

Also includes the following deprecation fixes:

- Update `.golangci.yml` config for several deprecated config settings
- Removed archived/deprecated linter `interfacer`
- Replaced `megacheck` with `gosimple`, `staticcheck`, and `unused`

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

CI & `make lint` in local machine

[contribution process]: https://git.io/fj2m9
