### PR TITLE
Add DesiredStateChanged event filter to filter out status updates

### DIFF
--- a/internal/controller/object/object.go
+++ b/internal/controller/object/object.go
@@ -191,6 +191,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, pollJit
 
 	cb := ctrl.NewControllerManagedBy(mgr).
 		Named(name).
+		WithEventFilter(resource.DesiredStateChanged()).
 		WithOptions(o.ForControllerRuntime()).
 		For(&v1alpha2.Object{})
 

--- a/internal/controller/observedobjectcollection/reconciler.go
+++ b/internal/controller/observedobjectcollection/reconciler.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
@@ -40,6 +39,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	"github.com/crossplane-contrib/provider-kubernetes/apis/object/v1alpha2"
 	"github.com/crossplane-contrib/provider-kubernetes/apis/observedobjectcollection/v1alpha1"
@@ -82,11 +82,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, pollJitter time.Duration) err
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
 		For(&v1alpha1.ObservedObjectCollection{}).
-		WithEventFilter(predicate.Or(
-			predicate.GenerationChangedPredicate{},
-			predicate.AnnotationChangedPredicate{},
-			predicate.LabelChangedPredicate{}),
-		).
+		WithEventFilter(resource.DesiredStateChanged()).
 		Complete(ratelimiter.NewReconciler(name, xperrors.WithSilentRequeueOnConflict(r), o.GlobalRateLimiter))
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
- Added an event filter using the [DesiredStateChanged](https://github.com/crossplane/crossplane-runtime/blob/0eae57e9c06bb807864bda7c1eece43671698ab7/pkg/resource/predicates.go#L51) predicate to the resource controllers so that updates to only labels, annotations (Crossplane's create pending/failed annotations will be ignored) and the spec will result in reconcile requests.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

- make test

- without this change,  when a `Object` resource's resourceVersion keeps changing due to changing `metadata.managedFields` of the managed K8s resource in `status.atProvider`, results in repeated reconciles of such Object in a short period of time( teal colored peaks in the below metrics graph).  With this change, such status updates doesn't result in reconcile spins (green plot, after the change):


<img width="1607" alt="Screenshot 2025-01-06 at 1 11 39 PM" src="https://github.com/user-attachments/assets/5d59e558-f75f-4e85-9f51-9777b29b1874" />

[contribution process]: https://git.io/fj2m9