### PR TITLE
(release-0.14): Update go version to 1.22.12 [SECURITY]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane-contrib/provider-kubernetes
 
-go 1.22.7
+go 1.22.12
 
 require (
 	github.com/Azure/kubelogin v0.1.1


### PR DESCRIPTION
### Description of your changes

This PR updates `go.mod` dependencies to fix the following:

| Name | Change | Type | Vulnerability | Severity |
|---|---|---|---|---|
| stdlib | `go1.22.7` -> `go1.22.12` | go-module | CVE-2024-45341 | Medium |
| stdlib | `go1.22.7` -> `go1.22.12` | go-module | CVE-2024-45336 | Medium |
| stdlib | `go1.22.7` -> `go1.22.12` | go-module | CVE-2025-22866 | - |

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

[contribution process]: https://git.io/fj2m9
