### PR TITLE
Add go.cachedir and go.mod.cachedir to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,19 @@ run: $(KUBECTL) generate
 manifests:
 	@$(INFO) Deprecated. Run make generate instead.
 
-.PHONY: cobertura submodules fallthrough test-integration run manifests
+# NOTE(hasheddan): the build submodule currently overrides XDG_CACHE_HOME in
+# order to force the Helm 3 to use the .work/helm directory. This causes Go on
+# Linux machines to use that directory as the build cache as well. We should
+# adjust this behavior in the build submodule because it is also causing Linux
+# users to duplicate their build cache, but for now we just make it easier to
+# identify its location in CI so that we cache between builds.
+go.cachedir:
+	@go env GOCACHE
+
+go.mod.cachedir:
+	@go env GOMODCACHE
+
+.PHONY: cobertura submodules fallthrough test-integration run manifests go.mod.cachedir go.cachedir
 
 generate.run: go.generate kustomize.gen
 


### PR DESCRIPTION
### Description of your changes

Adds `go.cachedir` and `go.mod.cachedir` to Makefile.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
