### PR TITLE
Integrate reusable workflow for provider package publishing

### DIFF
--- a/.github/workflows/publish-provider-package.yaml
+++ b/.github/workflows/publish-provider-package.yaml
@@ -1,0 +1,25 @@
+name: Publish Provider Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version string to use while publishing the package (e.g. v1.0.0-alpha.1)"
+        default: ''
+        required: false
+      go-version:
+        description: 'Go version to use if building needs to be done'
+        default: '1.22'
+        required: false
+
+jobs:
+  publish-provider-package:
+    uses: crossplane-contrib/provider-workflows/.github/workflows/publish-provider-non-family.yml@main
+    with:
+      repository: provider-kubernetes
+      version: ${{ github.event.inputs.version }}
+      go-version: ${{ github.event.inputs.go-version }}
+      cleanup-disk: true
+    secrets:
+      GHCR_PAT: ${{ secrets.GITHUB_TOKEN }}
+      XPKG_UPBOUND_TOKEN: ${{ secrets.XPKG_UPBOUND_TOKEN }}


### PR DESCRIPTION
### Description of your changes

This PR integrates reusable workflows for provider package publishing. Here is the workflow that wanted to integrate: https://github.com/crossplane-contrib/provider-workflows/blob/main/.github/workflows/publish-provider-non-family.yml

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
