### PR TITLE
Enable deleting objects when identity of manifest changes

### DIFF
--- a/internal/controller/object/object.go
+++ b/internal/controller/object/object.go
@@ -89,6 +89,7 @@ const (
 	errGetObservedState        = "cannot get observed state"
 	errGetDesiredState         = "cannot get desired state"
 	errUnmarshalTemplate       = "cannot unmarshal template"
+	errUnmarshalAtProvider     = "cannot unmarshal atProvider"
 	errFailedToMarshalExisting = "cannot marshal existing resource"
 
 	errGetReferencedResource       = "cannot get referenced resource"
@@ -363,6 +364,30 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 
 	if c.shouldWatch(obj) {
 		c.kindObserver.WatchResources(c.rest, obj.Spec.ProviderConfigReference.Name, manifest.GroupVersionKind())
+	}
+
+	if len(obj.Status.AtProvider.Manifest.Raw) > 0 && obj.GetDeletionPolicy() == xpv1.DeletionDelete {
+		atProviderManifest := &unstructured.Unstructured{}
+		if err := json.Unmarshal(obj.Status.AtProvider.Manifest.Raw, atProviderManifest); err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, errUnmarshalAtProvider)
+		}
+
+		// The name may be empty in the manifest, in which case we should use the name of the object
+		expectedName := manifest.GetName()
+		if expectedName == "" {
+			expectedName = obj.GetName()
+		}
+
+		// If the identity (i.e GVK, name or namespace) of the resource has changed, we need to delete the old resource
+		// before we can proceed with the observing the new resource.
+		if atProviderManifest.GroupVersionKind() != manifest.GroupVersionKind() ||
+			atProviderManifest.GetNamespace() != manifest.GetNamespace() ||
+			atProviderManifest.GetName() != expectedName {
+
+			if err := c.client.Delete(ctx, atProviderManifest); err != nil && !kerrors.IsNotFound(err) {
+				return managed.ExternalObservation{}, errors.Wrap(err, errDeleteObject)
+			}
+		}
 	}
 
 	current := manifest.DeepCopy()


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This is an attempt to move the discussion of https://github.com/crossplane-contrib/provider-kubernetes/issues/287 forward.

I think some of the issue is that the interfaces provided by `crossplane-runtime` (e.g the `managed.ExternalObservation`) doesn't allow to neatly encode the `Observe` function wanting to return a the operations required for a rename (e.g a Delete + Create). Without changing interfaces etc, which may be a heavy ask for the needs of potentially a single provider, we might have to be a little creative.

At first, I tried dealing with the Deletion of the previous resource in `Create`, but its problematic because `Observe` will try to update `atProvider`, which overwrites the information we need to delete a previously managed object.

Doing the deletion in `Observe` is a less noisy option code-wise, but of course means that "Observing" might entail "Delete something", and I'd love to hear opinions on this with possible solutions (e.g like updating the interface/structs from the runtime, expanding the Object resource to include resource references etc -- these are larger lifts, but it would be great to have clarity whether doing the requisite work for that would end up with the work being merged before committing to it).

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #287

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Running locally in a local dev environment.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
