### PR TITLE
feat: change logs support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ NPROCS ?= 1
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider
+GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)
 GO_SUBDIRS += cmd internal apis pkg
 GO111MODULE = on
 GOLANGCILINT_VERSION = 1.62.0

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	go.uber.org/zap v1.27.0
 	golang.org/x/oauth2 v0.21.0
 	golang.org/x/sync v0.11.0
+	google.golang.org/grpc v1.65.0
 	k8s.io/api v0.31.0
 	k8s.io/apimachinery v0.31.0
 	k8s.io/client-go v0.31.0
@@ -99,7 +100,6 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240528184218-531527333157 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240701130421-f6361c86f094 // indirect
-	google.golang.org/grpc v1.65.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/retry.v1 v1.0.3 // indirect

--- a/internal/controller/object/object.go
+++ b/internal/controller/object/object.go
@@ -234,6 +234,10 @@ func Setup(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, pollJit
 		reconcilerOptions = append(reconcilerOptions, managed.WithManagementPolicies())
 	}
 
+	if o.Features.Enabled(feature.EnableAlphaChangeLogs) {
+		reconcilerOptions = append(reconcilerOptions, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
+	}
+
 	if err := mgr.Add(statemetrics.NewMRStateRecorder(
 		mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha2.ObjectList{}, o.MetricOptions.PollStateMetricInterval)); err != nil {
 		return err

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2025 The Crossplane Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package version contains the version of this repo
+package version
+
+// Version will be overridden with the current version at build time using the -X linker flag
+var Version = "0.0.0"


### PR DESCRIPTION
### Description of your changes

This PR enables support for change logs in this provider. This functionality is not enabled by default and must be opted-in via `--enable-changelogs`.

When enabled, this provider will create a change logs gRPC client that connects to the change logs sidecar container via unix domain socket at `/var/run/changelogs/changelogs.sock`. This gRPC client will then be passed to the managed reconcilers of this provider so that all change operations can be recorded.

It is also expected for the change logs sidecar container to be injected into this provider via a `DeploymentRuntimeConfig` as demonstrated in https://github.com/jbw976/change-log-sidecar/blob/main/drc.yaml. 

Change logs design doc: https://github.com/crossplane/crossplane/blob/main/design/one-pager-change-logs.md 

Part of https://github.com/crossplane/crossplane/issues/5924

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I have tested this code using most of the development workflow described in https://github.com/jbw976/change-log-sidecar/blob/main/DEVELOPMENT.md, skipping the portions for locally building the sidecar container, since there is an officially published image available now upstream at `xpkg.crossplane.io/crossplane/changelogs-sidecar:v0.0.0-20250417165647-56fb76b5075e`.

We can see that creating a claim results in the expected 3 provider-kubernetes `Objects` that are healthy:
```
❯ crossplane beta trace traceperf.trace-perf.crossplane.io/traceperf-tester
NAME                                   SYNCED   READY   STATUS
TracePerf/traceperf-tester (default)   True     True    Available
└─ XTracePerf/traceperf-tester-8j242   True     True    Available
   ├─ Object/object-0                  True     True    Available
   ├─ Object/object-1                  True     True    Available
   └─ Object/object-2                  True     True    Available
```

After creation, we perform an update operation on the claim (and therefore underlying `Objects`), and then delete the claim which cleans up all resources. The change logs reflect this life cycle with 3 entries, 1 for each `Object`, first of type `OPERATION_TYPE_CREATE`, then `OPERATION_TYPE_UPDATE`, then finally `OPERATION_TYPE_DELETE`:
```
❯ kubectl -n crossplane-system logs -l pkg.crossplane.io/provider=provider-kubernetes -c changelogs-sidecar | jq '.timestamp + " " + .provider + " " + .name + " " + .operation'
"2025-04-18T08:44:27Z provider-kubernetes:v0.18.0 object-0 OPERATION_TYPE_CREATE"
"2025-04-18T08:44:27Z provider-kubernetes:v0.18.0 object-1 OPERATION_TYPE_CREATE"
"2025-04-18T08:44:27Z provider-kubernetes:v0.18.0 object-2 OPERATION_TYPE_CREATE"
"2025-04-18T08:45:08Z provider-kubernetes:v0.18.0 object-1 OPERATION_TYPE_UPDATE"
"2025-04-18T08:45:08Z provider-kubernetes:v0.18.0 object-2 OPERATION_TYPE_UPDATE"
"2025-04-18T08:45:08Z provider-kubernetes:v0.18.0 object-0 OPERATION_TYPE_UPDATE"
"2025-04-18T08:46:25Z provider-kubernetes:v0.18.0 object-1 OPERATION_TYPE_DELETE"
"2025-04-18T08:46:25Z provider-kubernetes:v0.18.0 object-0 OPERATION_TYPE_DELETE"
"2025-04-18T08:46:25Z provider-kubernetes:v0.18.0 object-2 OPERATION_TYPE_DELETE"
```

[contribution process]: https://git.io/fj2m9
