### PR TITLE
build: pass robot token credentials to publishing to mirror registry

### DIFF
--- a/.github/workflows/publish-provider-package.yaml
+++ b/.github/workflows/publish-provider-package.yaml
@@ -22,4 +22,6 @@ jobs:
       cleanup-disk: true
     secrets:
       GHCR_PAT: ${{ secrets.GITHUB_TOKEN }}
-      XPKG_UPBOUND_TOKEN: ${{ secrets.XPKG_UPBOUND_TOKEN }}
+      XPKG_MIRROR_TOKEN: ${{ secrets.XPKG_TOKEN }}
+      XPKG_MIRROR_ACCESS_ID: ${{ secrets.XPKG_ACCESS_ID }}
+


### PR DESCRIPTION
### Description of your changes

Now that https://github.com/crossplane-contrib/provider-workflows/pull/15 has been merged, this PR updates the publishing workflow to pass the correct robot credentials. It looks like this repo already had some defined, so let's reuse them 🙏 

Once this PR is merged, we should still successfully continue to publish to ghcr.io and mirror to xpkg.upbound.io.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

It hasn't explicitly been tested - we'll see how CI goes, but I expect the real path won't be tested until we run a publishing 😇 

[contribution process]: https://git.io/fj2m9
