### PR TITLE
Feature: use proxy-url from cluster in kubeconfig if set

### DIFF
--- a/pkg/kube/client/client.go
+++ b/pkg/kube/client/client.go
@@ -213,11 +213,7 @@ func fromAPIConfig(c *api.Config) (*rest.Config, error) {
 			// See https://pkg.go.dev/k8s.io/client-go/rest#Config
 			if cluster.ProxyURL != "" {
 				return func(*http.Request) (*url.URL, error) {
-					parsedURL, err := url.Parse(cluster.ProxyURL)
-					if err != nil {
-					  return nil, err
-					}
-					return parsedURL, nil
+					return url.Parse(cluster.ProxyURL)
 				}
 			}
 			// Otherwhise leave proxy configuration untouched

--- a/pkg/kube/client/client.go
+++ b/pkg/kube/client/client.go
@@ -213,7 +213,11 @@ func fromAPIConfig(c *api.Config) (*rest.Config, error) {
 			// See https://pkg.go.dev/k8s.io/client-go/rest#Config
 			if cluster.ProxyURL != "" {
 				return func(*http.Request) (*url.URL, error) {
-					return url.Parse(cluster.ProxyURL)
+					parsedURL, err := url.Parse(cluster.ProxyURL)
+					if err != nil {
+					  return nil, err
+					}
+					return parsedURL, nil
 				}
 			}
 			// Otherwhise leave proxy configuration untouched


### PR DESCRIPTION
### Description of your changes

Clusters in kubeconfig may have a field `proxy-url` that needs to be respected to reach the specified endpoints.
Currently, `client.go` in the provider does not respect this.

`struct rest.Config` created in `client.go` offers a field `proxy:func(*http.Request) (*url.URL, error)` that may be used to this end. 

### How has this code been tested

Just compile/deploy-local as of now. Want to see if there is interest.

[contribution process]: https://git.io/fj2m9
