### PR TITLE
fix watches for Namespaced Objects

### DIFF
--- a/internal/controller/cluster/object/informers.go
+++ b/internal/controller/cluster/object/informers.go
@@ -243,7 +243,7 @@ func (i *resourceInformers) cleanupResourceInformers(ctx context.Context) {
 		}
 
 		ca.cancelFn()
-		i.log.Info("Stopped resource watch", "provider config", gc.providerConfig, "gvk", gc.gvk)
+		i.log.Info("Stopped resource watch", "providerConfig", gc.providerConfig, "gvk", gc.gvk)
 		i.lock.Lock()
 		delete(i.resourceCaches, gc)
 		i.lock.Unlock()

--- a/internal/controller/namespaced/object/indexes.go
+++ b/internal/controller/namespaced/object/indexes.go
@@ -69,7 +69,7 @@ func IndexByProviderGVK(o client.Object) []string {
 	// We don't expect errors here, as the parseManifest function is already called
 	// in the reconciler and the desired object already validated.
 	d, _ := parseManifest(obj)
-	providerConfigKey := fmt.Sprintf("%s:%s:%s", obj.Spec.ProviderConfigReference.Name, obj.Spec.ProviderConfigReference.Kind, obj.GetNamespace())
+	providerConfigKey := providerConfigRefKey(obj)
 	keys = append(keys, refKeyProviderGVK(providerConfigKey, d.GetKind(), d.GroupVersionKind().Group, d.GroupVersionKind().Version)) // unification is done by the informer.
 
 	// unification is done by the informer.


### PR DESCRIPTION
### Description of your changes

Looks like watches are broken for namespaced Objects introduced with crossplane v2 support. The problem manifests like that:
- I create two Objects, one Cluster-level and one Namespaced
- I see log messages about the watches being started for both Objects
```
2025-09-03T13:12:10.456Z        INFO    provider-kubernetes     Starting resource watch {"controller": "managed/object.kubernetes.crossplane.io", "providerConfig": "default", "gvk": "example.com/v1alpha1, Kind=Example"}
2025-09-03T13:12:10.463Z        INFO    provider-kubernetes     Starting resource watch {"controller": "managed/object.kubernetes.m.crossplane.io", "providerConfig": "ClusterProviderConfig/default/default", "gvk": "example.com/v1alpha1, Kind=Example"}
```
- but shortly after, the Namespaced watch is garbage-collected
```
2025-09-03T13:12:54.991Z        DEBUG   provider-kubernetes     Running garbage collection for resource informers       {"controller": "managed/object.kubernetes.crossplane.io", "count": 1}
2025-09-03T13:12:54.991Z        DEBUG   provider-kubernetes     Running garbage collection for resource informers       {"controller": "managed/object.kubernetes.m.crossplane.io", "count": 1}
2025-09-03T13:12:54.998Z        INFO    provider-kubernetes     Stopped resource watch  {"controller": "managed/object.kubernetes.m.crossplane.io", "provider config": "ClusterProviderConfig/default/default", "gvk": "example.com/v1alpha1, Kind=Example"}
```

Looks like this is happening because of mismatch between index key generated in `internal/controller/namespaced/object/indexes.go`:
```
	providerConfigKey := fmt.Sprintf("%s:%s:%s", obj.Spec.ProviderConfigReference.Name, obj.Spec.ProviderConfigReference.Kind, obj.GetNamespace())
	// will look like "default:ClusterProviderConfig:default"
```
and the key generated in `internal/controller/namespaced/object/object.go`:
```
	if c.shouldWatch(obj) {
		c.kindObserver.WatchResources(c.rest, providerConfigRefKey(obj), manifest.GroupVersionKind())
	}
```
which uses `providerConfigRefKey` from `internal/controller/namespaced/object/indexes.go`:
```
func providerConfigRefKey(obj *v1alpha1.Object) string {
	return fmt.Sprintf("%s/%s/%s", obj.Spec.ProviderConfigReference.Kind, obj.GetNamespace(), obj.Spec.ProviderConfigReference.Name)
}
```

Eventually this leads to `cleanupResourceInformers` in `internal/controller/namespaced/object/informers.go` to look for objects with key like `ClusterProviderConfig/default/default.Example.example.com.v1alpha1` instead of `default:ClusterProviderConfig:default.Example.example.com.v1alpha1` which exists in the index.
```
		if err := i.objectsCache.List(ctx, &list, client.MatchingFields{resourceRefGVKsIndex: refKeyProviderGVK(gc.providerConfig, gc.gvk.Kind, gc.gvk.Group, gc.gvk.Version)}); err != nil {
```

I've changed the implementation to use `providerConfigRefKey` to generate key in both cases to prevent this mismatch.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I've created following script to test this logic:
```
#!/usr/bin/env bash

set -Eeuo pipefail

cat <<EOF | kubectl apply -f -
apiVersion: kubernetes.m.crossplane.io/v1alpha1
kind: ClusterProviderConfig
metadata:
  name: default
spec:
  credentials:
    source: InjectedIdentity
---
apiVersion: kubernetes.crossplane.io/v1alpha1
kind: ProviderConfig
metadata:
  name: default
spec:
  credentials:
    source: InjectedIdentity
---
apiVersion: kubernetes.crossplane.io/v1alpha2
kind: Object
metadata:
  name: map1
spec:
  watch: true
  forProvider:
    manifest:
      apiVersion: v1
      kind: ConfigMap
      metadata:
        name: map1
        namespace: default
      data:
        value: initial
---
apiVersion: kubernetes.m.crossplane.io/v1alpha1
kind: Object
metadata:
  name: map2
  namespace: default
spec:
  watch: true
  forProvider:
    manifest:
      apiVersion: v1
      kind: ConfigMap
      metadata:
        name: map2
        namespace: default
      data:
        value: initial
EOF

kubectl get objects.kubernetes.crossplane.io/map1 \
  --output yaml |
  yq '.status.atProvider.manifest.data.value'
kubectl get objects.kubernetes.m.crossplane.io/map2 \
  --output yaml |
  yq '.status.atProvider.manifest.data.value'

kubectl patch configmaps/map1 \
    --type=merge \
    --patch='{"data":{"value":"update1"}}'
kubectl patch configmaps/map2 \
    --type=merge \
    --patch='{"data":{"value":"update1"}}'

kubectl get objects.kubernetes.crossplane.io/map1 \
  --output yaml |
  yq '.status.atProvider.manifest.data.value'
kubectl get objects.kubernetes.m.crossplane.io/map2 \
  --output yaml |
  yq '.status.atProvider.manifest.data.value'

kubectl patch configmaps/map1 \
    --type=merge \
    --patch='{"data":{"value":"update2"}}'
kubectl patch configmaps/map2 \
    --type=merge \
    --patch='{"data":{"value":"update2"}}'

kubectl get objects.kubernetes.crossplane.io/map1 \
  --output yaml |
  yq '.status.atProvider.manifest.data.value'
kubectl get objects.kubernetes.m.crossplane.io/map2 \
  --output yaml |
  yq '.status.atProvider.manifest.data.value'
```

Before the fix the output was:
```
"initial"
"initial"
configmap/map1 patched
configmap/map2 patched
"update1"
"initial"
configmap/map1 patched
configmap/map2 patched
"update2"
"initial"
```
As you can see the ConfigMap was changed, but this change was not transferred to the Object.

After the fix:
```
"initial"
"initial"
configmap/map1 patched
configmap/map2 patched
"update1"
"update1"
configmap/map1 patched
configmap/map2 patched
"update2"
"update2"
```
