### PR TITLE
Remove xpkg.upbound.io references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ so using the Crossplane CLI in a Kubernetes cluster where Crossplane is
 installed:
 
 ```console
-crossplane xpkg install provider xpkg.upbound.io/upbound/provider-kubernetes:v0.16.0
+crossplane xpkg install provider xpkg.crossplane.io/crossplane-contrib/provider-kubernetes:v1.0.0
 ```
 
 You may also manually install `provider-kubernetes` by creating a `Provider` directly:
@@ -25,7 +25,7 @@ kind: Provider
 metadata:
   name: provider-kubernetes
 spec:
-  package: xpkg.upbound.io/upbound/provider-kubernetes:v0.16.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-kubernetes:v1.0.0
 ```
 
 ## Developing locally

--- a/examples/cluster/provider/provider-in-cluster.yaml
+++ b/examples/cluster/provider/provider-in-cluster.yaml
@@ -4,7 +4,7 @@ kind: Provider
 metadata:
   name: provider-kubernetes
 spec:
-  package: xpkg.upbound.io/upbound/provider-kubernetes:v0.16.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-kubernetes:v1.0.0
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig

--- a/examples/namespaced/provider/provider-in-cluster.yaml
+++ b/examples/namespaced/provider/provider-in-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   name: provider-kubernetes
   namespace: crossplane-system
 spec:
-  package: xpkg.upbound.io/upbound/provider-kubernetes:v0.16.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-kubernetes:v1.0.0
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig


### PR DESCRIPTION
### Description of your changes

Update README file and examples to use xpkg.crossplane.io in place of xpkg.upbound.io

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

N/A
