### PR TITLE
feat: add SafeStart capability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	golang.org/x/sync v0.13.0
 	google.golang.org/grpc v1.68.1
 	k8s.io/api v0.33.0
+	k8s.io/apiextensions-apiserver v0.33.0
 	k8s.io/apimachinery v0.33.0
 	k8s.io/client-go v0.33.0
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff
@@ -106,7 +107,6 @@ require (
 	gopkg.in/retry.v1 v1.0.3 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.33.0 // indirect
 	k8s.io/code-generator v0.33.0 // indirect
 	k8s.io/component-base v0.33.0 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7 // indirect

--- a/internal/controller/cluster/config/config.go
+++ b/internal/controller/cluster/config/config.go
@@ -50,3 +50,14 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 		Watches(&v1alpha1.ProviderConfigUsage{}, &resource.EnqueueRequestForProviderConfig{}).
 		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
 }
+
+// SetupGated adds a controller that reconciles ProviderConfigs by accounting for
+// their current usage.
+func SetupGated(mgr ctrl.Manager, o controller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup reconciler", "gvk", v1alpha1.ProviderConfigGroupVersionKind.String())
+		}
+	}, v1alpha1.ProviderConfigGroupVersionKind, v1alpha1.ProviderConfigUsageGroupVersionKind)
+	return nil
+}

--- a/internal/controller/cluster/kubernetes.go
+++ b/internal/controller/cluster/kubernetes.go
@@ -28,7 +28,7 @@ import (
 	"github.com/crossplane-contrib/provider-kubernetes/internal/controller/cluster/observedobjectcollection"
 )
 
-// Setup creates all Template controllers with the supplied logger and adds them to
+// Setup creates all Kubernetes controllers with the supplied logger and adds them to
 // the supplied manager.
 func Setup(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, pollJitter time.Duration, pollJitterPercentage uint) error {
 	if err := config.Setup(mgr, o); err != nil {
@@ -38,6 +38,22 @@ func Setup(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, pollJit
 		return err
 	}
 	if err := observedobjectcollection.Setup(mgr, o, pollJitter); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetupGated registers all Kubernetes controllers setup functions with the supplied
+// logger and adds them to the supplied manager. The controller setup calls are
+// initiated after the relevant CRDs become available.
+func SetupGated(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, pollJitter time.Duration, pollJitterPercentage uint) error {
+	if err := config.SetupGated(mgr, o); err != nil {
+		return err
+	}
+	if err := object.SetupGated(mgr, o, sanitizeSecrets, pollJitterPercentage); err != nil {
+		return err
+	}
+	if err := observedobjectcollection.SetupGated(mgr, o, pollJitter); err != nil {
 		return err
 	}
 	return nil

--- a/internal/controller/cluster/object/object.go
+++ b/internal/controller/cluster/object/object.go
@@ -247,6 +247,17 @@ func Setup(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, pollJit
 	), o.GlobalRateLimiter))
 }
 
+// SetupGated registers a controller setup function that reconciles Object managed resources.
+// The controller setup is initiated after the CRD for Object becomes available.
+func SetupGated(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, pollJitterPercentage uint) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o, sanitizeSecrets, pollJitterPercentage); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup reconciler", "gvk", v1alpha2.ObjectGroupVersionKind.String())
+		}
+	}, v1alpha2.ObjectGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube            client.Client
 	usage           legacyTracker

--- a/internal/controller/namespaced/config/config.go
+++ b/internal/controller/namespaced/config/config.go
@@ -78,3 +78,14 @@ func setupClusterProviderConfig(mgr ctrl.Manager, o controller.Options) error {
 		Watches(&v1alpha1.ProviderConfigUsage{}, &resource.EnqueueRequestForProviderConfig{}).
 		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
 }
+
+// SetupGated adds a controller that reconciles ProviderConfigs by accounting for
+// their current usage.
+func SetupGated(mgr ctrl.Manager, o controller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup reconcilers", "gvk", v1alpha1.ClusterProviderConfigGroupVersionKind.String(), "gvk", v1alpha1.ProviderConfigGroupVersionKind.String())
+		}
+	}, v1alpha1.ClusterProviderConfigGroupVersionKind, v1alpha1.ProviderConfigGroupVersionKind, v1alpha1.ProviderConfigUsageGroupVersionKind)
+	return nil
+}

--- a/internal/controller/namespaced/kubernetes.go
+++ b/internal/controller/namespaced/kubernetes.go
@@ -28,7 +28,7 @@ import (
 	"github.com/crossplane-contrib/provider-kubernetes/internal/controller/namespaced/observedobjectcollection"
 )
 
-// Setup creates all Template controllers with the supplied logger and adds them to
+// Setup creates all Kubernetes controllers with the supplied logger and adds them to
 // the supplied manager.
 func Setup(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, pollJitter time.Duration, pollJitterPercentage uint) error {
 	if err := config.Setup(mgr, o); err != nil {
@@ -38,6 +38,22 @@ func Setup(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, pollJit
 		return err
 	}
 	if err := observedobjectcollection.Setup(mgr, o, pollJitter); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetupGated registers all Kubernetes controllers setup functions with the supplied
+// logger and adds them to the supplied manager. The controller setup calls are
+// initiated after the relevant CRDs become available.
+func SetupGated(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, pollJitter time.Duration, pollJitterPercentage uint) error {
+	if err := config.SetupGated(mgr, o); err != nil {
+		return err
+	}
+	if err := object.SetupGated(mgr, o, sanitizeSecrets, pollJitterPercentage); err != nil {
+		return err
+	}
+	if err := observedobjectcollection.SetupGated(mgr, o, pollJitter); err != nil {
 		return err
 	}
 	return nil

--- a/internal/controller/namespaced/object/object.go
+++ b/internal/controller/namespaced/object/object.go
@@ -248,6 +248,17 @@ func Setup(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, pollJit
 	), o.GlobalRateLimiter))
 }
 
+// SetupGated registers a gated controller that reconciles Object managed resources.
+// The controller setup is initiated after the CRD for Object becomes available.
+func SetupGated(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, pollJitterPercentage uint) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o, sanitizeSecrets, pollJitterPercentage); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup reconciler", "gvk", v1alpha1.ObjectGroupVersionKind.String())
+		}
+	}, v1alpha1.ObjectGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube            client.Client
 	usage           modernTracker

--- a/internal/controller/namespaced/observedobjectcollection/reconciler.go
+++ b/internal/controller/namespaced/observedobjectcollection/reconciler.go
@@ -88,6 +88,18 @@ func Setup(mgr ctrl.Manager, o controller.Options, pollJitter time.Duration) err
 		Complete(ratelimiter.NewReconciler(name, xperrors.WithSilentRequeueOnConflict(r), o.GlobalRateLimiter))
 }
 
+// SetupGated registers a controller setup function that reconciles
+// ObservedObjectCollection managed resources. The controller setup is
+// initiated after the CRD for ObservedObjectCollection becomes available.
+func SetupGated(mgr ctrl.Manager, o controller.Options, pollJitter time.Duration) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o, pollJitter); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup reconciler", "gvk", observedobjectcollectionv1alpha1.ObservedObjectCollectionGroupVersionKind.String())
+		}
+	}, observedobjectcollectionv1alpha1.ObservedObjectCollectionGroupVersionKind)
+	return nil
+}
+
 // Reconcile fetches objects specified by their GVK and label selector
 // and creates observed-only Objects for the matches.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, error error) { //nolint:gocyclo

--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -17,3 +17,6 @@ metadata:
       - An `Object` resource type that is to manage Kubernetes Objects.
       - A managed resource controller that reconciles `Object` typed resources and manages
       arbitrary Kubernetes Objects.
+spec:
+  capabilities:
+    - SafeStart


### PR DESCRIPTION
### Description of your changes

Adds safe start capability that allows selectively activating MRDs

Fixes #400

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```shell
kind create cluster --name mrap-test
helm install crossplane --namespace crossplane-system --create-namespace crossplane-stable/crossplane --set provider.defaultActivations={}
make KIND_CLUSTER_NAME=mrap-test build local.xpkg.deploy.provider.provider-kubernetes

kubectl get mrd
```
Observe that MRDs for provider kubernetes exists and inactive
```
NAME                                                   STATE      ESTABLISHED   AGE
objects.kubernetes.crossplane.io                       Inactive   False         23m
objects.kubernetes.m.crossplane.io                     Inactive   False         23m
observedobjectcollections.kubernetes.crossplane.io     Inactive   False         23m
observedobjectcollections.kubernetes.m.crossplane.io   Inactive   False         23m
```
Observe that only provider config CRDs exists
```
k get crd | grep 'kubernetes.*crossplane.io'

clusterproviderconfigs.kubernetes.m.crossplane.io               2025-10-15T07:25:06Z
providerconfigs.kubernetes.crossplane.io                        2025-10-15T07:25:06Z
providerconfigs.kubernetes.m.crossplane.io                      2025-10-15T07:25:06Z
providerconfigusages.kubernetes.crossplane.io                   2025-10-15T07:25:06Z
providerconfigusages.kubernetes.m.crossplane.io                 2025-10-15T07:25:06Z
```

activate all MRDs by applying the below `ManagedResourceActivationPolicy`
```yaml
apiVersion: apiextensions.crossplane.io/v1alpha1
kind: ManagedResourceActivationPolicy
metadata:
  name: default
spec:
  activate:
  - "*"
```

Observe that the MRDs switched to active now
```
kubectl get mrd

NAME                                                   STATE    ESTABLISHED   AGE
objects.kubernetes.crossplane.io                       Active   True          27m
objects.kubernetes.m.crossplane.io                     Active   True          27m
observedobjectcollections.kubernetes.crossplane.io     Active   True          27m
observedobjectcollections.kubernetes.m.crossplane.io   Active   True          27m
```
Observe that the CRDs exist
```
k get crd | grep 'kubernetes.*crossplane.io'

clusterproviderconfigs.kubernetes.m.crossplane.io               2025-10-15T07:25:06Z
objects.kubernetes.crossplane.io                                2025-10-15T08:13:21Z
objects.kubernetes.m.crossplane.io                              2025-10-15T08:13:21Z
observedobjectcollections.kubernetes.crossplane.io              2025-10-15T08:13:21Z
observedobjectcollections.kubernetes.m.crossplane.io            2025-10-15T08:13:21Z
providerconfigs.kubernetes.crossplane.io                        2025-10-15T07:25:06Z
providerconfigs.kubernetes.m.crossplane.io                      2025-10-15T07:25:06Z
providerconfigusages.kubernetes.crossplane.io                   2025-10-15T07:25:06Z
providerconfigusages.kubernetes.m.crossplane.io                 2025-10-15T07:25:06Z
```

[contribution process]: https://git.io/fj2m9
