### PR TITLE
Add configurable Object DeletionPropagationPolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,20 +79,20 @@ locally running controller.
       ```
       SA=$(kubectl -n crossplane-system get sa -o name | grep provider-kubernetes | sed -e 's|serviceaccount\/|crossplane-system:|g')
       kubectl create clusterrolebinding provider-kubernetes-admin-binding --clusterrole cluster-admin --serviceaccount="${SA}"
-      kubectl apply -f examples/provider/config-in-cluster.yaml
+      kubectl apply -f examples/namespaced/provider/config-in-cluster.yaml
       ```
   1. If provider kubernetes running outside the cluster (e.g. running locally with `make run`)
 
       ```
       KUBECONFIG=$(kind get kubeconfig --name local-dev | sed -e 's|server:\s*.*$|server: http://localhost:8081|g')
       kubectl -n crossplane-system create secret generic cluster-config --from-literal=kubeconfig="${KUBECONFIG}"
-      kubectl apply -f examples/provider/config.yaml
+      kubectl apply -f examples/namespaced/provider/config.yaml
       ```
 
-1. Now you can create `Object` resources with provider reference, see [sample object.yaml](examples/object/object.yaml).
+1. Now you can create `Object` resources with provider reference, see [sample object.yaml](examples/namespaced/object/object.yaml).
 
     ```
-    kubectl create -f examples/object/object.yaml
+    kubectl create -f examples/namespaced/object/object.yaml
     ```
 
 ### Cleanup

--- a/apis/cluster/object/v1alpha2/types.go
+++ b/apis/cluster/object/v1alpha2/types.go
@@ -80,6 +80,12 @@ type ObjectParameters struct {
 	// +kubebuilder:validation:EmbeddedResource
 	// +kubebuilder:pruning:PreserveUnknownFields
 	Manifest runtime.RawExtension `json:"manifest"`
+
+	// Deletion policy for created kubernetes object, defaults to Background
+	// +optional
+	// +kubebuilder:validation:Enum=Orphan;Background;Foreground
+	// +kubebuilder:default=Background
+	DeletionPropagationPolicy metav1.DeletionPropagation `json:"deletionPropagationPolicy"`
 }
 
 // ObjectObservation are the observable fields of a Object.

--- a/apis/namespaced/object/v1alpha1/types.go
+++ b/apis/namespaced/object/v1alpha1/types.go
@@ -81,6 +81,12 @@ type ObjectParameters struct {
 	// +kubebuilder:validation:EmbeddedResource
 	// +kubebuilder:pruning:PreserveUnknownFields
 	Manifest runtime.RawExtension `json:"manifest"`
+
+	// Deletion policy for created kubernetes object, defaults to Background
+	// +optional
+	// +kubebuilder:validation:Enum=Orphan;Background;Foreground
+	// +kubebuilder:default=Background
+	DeletionPropagationPolicy metav1.DeletionPropagation `json:"deletionPropagationPolicy"`
 }
 
 // ObjectObservation are the observable fields of a Object.

--- a/examples/namespaced/provider/config.yaml
+++ b/examples/namespaced/provider/config.yaml
@@ -11,6 +11,7 @@ apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: ClusterProviderConfig
 metadata:
   name: kubernetes-provider
+  namespace: default
 spec:
   credentials:
     source: Secret

--- a/examples/namespaced/provider/config.yaml
+++ b/examples/namespaced/provider/config.yaml
@@ -11,7 +11,6 @@ apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: ClusterProviderConfig
 metadata:
   name: kubernetes-provider
-  namespace: default
 spec:
   credentials:
     source: Secret

--- a/internal/controller/cluster/object/object.go
+++ b/internal/controller/cluster/object/object.go
@@ -471,7 +471,13 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalDelete{}, errors.New(errNotKubernetesObject)
 	}
 
-	c.logger.Debug("Deleting", "resource", obj)
+	// Apply deletion policy set in the Object spec
+	propagationPolicy := obj.Spec.ForProvider.DeletionPropagationPolicy
+	deleteOptions := &client.DeleteOptions{
+		PropagationPolicy: &propagationPolicy,
+	}
+
+	c.logger.Debug("Deleting", "resource", obj, "propagationPolicy", obj.Spec.ForProvider.DeletionPropagationPolicy)
 
 	res, err := parseManifest(obj)
 	if err != nil {
@@ -481,12 +487,6 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 	// SSA is enabled
 	if c.desiredStateCacheCleanupFn != nil {
 		c.desiredStateCacheCleanupFn()
-	}
-
-	// Apply deletion policy set in the Object spec
-	propagationPolicy := obj.Spec.ForProvider.DeletionPropagationPolicy
-	deleteOptions := &client.DeleteOptions{
-		PropagationPolicy: &propagationPolicy,
 	}
 
 	return managed.ExternalDelete{}, errors.Wrap(resource.IgnoreNotFound(c.client.Delete(ctx, res, deleteOptions)), errDeleteObject)

--- a/internal/controller/cluster/object/object.go
+++ b/internal/controller/cluster/object/object.go
@@ -31,7 +31,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -484,11 +483,8 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 		c.desiredStateCacheCleanupFn()
 	}
 
-	// Use Foreground deletion propagation to ensure that dependent resources
-	// (like Pods owned by a Job) are properly deleted. This prevents orphaned
-	// Pods when deleting Jobs and other owner resources.
-	// See: https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
-	propagationPolicy := metav1.DeletePropagationForeground
+	// Apply deletion policy set in the Object spec
+	propagationPolicy := obj.Spec.ForProvider.DeletionPropagationPolicy
 	deleteOptions := &client.DeleteOptions{
 		PropagationPolicy: &propagationPolicy,
 	}

--- a/internal/controller/cluster/object/object.go
+++ b/internal/controller/cluster/object/object.go
@@ -31,6 +31,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -482,7 +483,17 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 	if c.desiredStateCacheCleanupFn != nil {
 		c.desiredStateCacheCleanupFn()
 	}
-	return managed.ExternalDelete{}, errors.Wrap(resource.IgnoreNotFound(c.client.Delete(ctx, res)), errDeleteObject)
+
+	// Use Foreground deletion propagation to ensure that dependent resources
+	// (like Pods owned by a Job) are properly deleted. This prevents orphaned
+	// Pods when deleting Jobs and other owner resources.
+	// See: https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+	propagationPolicy := metav1.DeletePropagationForeground
+	deleteOptions := &client.DeleteOptions{
+		PropagationPolicy: &propagationPolicy,
+	}
+
+	return managed.ExternalDelete{}, errors.Wrap(resource.IgnoreNotFound(c.client.Delete(ctx, res, deleteOptions)), errDeleteObject)
 }
 
 func (c *external) Disconnect(ctx context.Context) error {

--- a/internal/controller/namespaced/object/object.go
+++ b/internal/controller/namespaced/object/object.go
@@ -472,7 +472,13 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalDelete{}, errors.New(errNotKubernetesObject)
 	}
 
-	c.logger.Debug("Deleting", "resource", obj)
+	// Apply deletion policy set in the Object spec
+	propagationPolicy := obj.Spec.ForProvider.DeletionPropagationPolicy
+	deleteOptions := &client.DeleteOptions{
+		PropagationPolicy: &propagationPolicy,
+	}
+
+	c.logger.Debug("Deleting", "resource", obj, "propagationPolicy", obj.Spec.ForProvider.DeletionPropagationPolicy)
 
 	res, err := parseManifest(obj)
 	if err != nil {
@@ -482,12 +488,6 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 	// SSA is enabled
 	if c.desiredStateCacheCleanupFn != nil {
 		c.desiredStateCacheCleanupFn()
-	}
-
-	// Apply deletion policy set in the Object spec
-	propagationPolicy := obj.Spec.ForProvider.DeletionPropagationPolicy
-	deleteOptions := &client.DeleteOptions{
-		PropagationPolicy: &propagationPolicy,
 	}
 
 	return managed.ExternalDelete{}, errors.Wrap(resource.IgnoreNotFound(c.client.Delete(ctx, res, deleteOptions)), errDeleteObject)

--- a/internal/controller/namespaced/object/object.go
+++ b/internal/controller/namespaced/object/object.go
@@ -31,6 +31,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -483,7 +484,15 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 	if c.desiredStateCacheCleanupFn != nil {
 		c.desiredStateCacheCleanupFn()
 	}
-	return managed.ExternalDelete{}, errors.Wrap(resource.IgnoreNotFound(c.client.Delete(ctx, res)), errDeleteObject)
+
+	// Use Foreground deletion propagation to ensure that dependent resources (like Pods owned by a Job) are properly deleted
+	// See: https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+	propagationPolicy := metav1.DeletePropagationForeground
+	deleteOptions := &client.DeleteOptions{
+		PropagationPolicy: &propagationPolicy,
+	}
+
+	return managed.ExternalDelete{}, errors.Wrap(resource.IgnoreNotFound(c.client.Delete(ctx, res, deleteOptions)), errDeleteObject)
 }
 
 func (c *external) Disconnect(ctx context.Context) error {

--- a/internal/controller/namespaced/object/object.go
+++ b/internal/controller/namespaced/object/object.go
@@ -31,7 +31,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -485,9 +484,8 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 		c.desiredStateCacheCleanupFn()
 	}
 
-	// Use Foreground deletion propagation to ensure that dependent resources (like Pods owned by a Job) are properly deleted
-	// See: https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
-	propagationPolicy := metav1.DeletePropagationForeground
+	// Apply deletion policy set in the Object spec
+	propagationPolicy := obj.Spec.ForProvider.DeletionPropagationPolicy
 	deleteOptions := &client.DeleteOptions{
 		PropagationPolicy: &propagationPolicy,
 	}

--- a/package/crds/kubernetes.crossplane.io_objects.yaml
+++ b/package/crds/kubernetes.crossplane.io_objects.yaml
@@ -548,6 +548,15 @@ spec:
               forProvider:
                 description: ObjectParameters are the configurable fields of a Object.
                 properties:
+                  deletionPropagationPolicy:
+                    default: Background
+                    description: Deletion policy for created kubernetes object, defaults
+                      to Background
+                    enum:
+                    - Orphan
+                    - Background
+                    - Foreground
+                    type: string
                   manifest:
                     description: Raw JSON representation of the kubernetes object
                       to be created.

--- a/package/crds/kubernetes.m.crossplane.io_objects.yaml
+++ b/package/crds/kubernetes.m.crossplane.io_objects.yaml
@@ -122,6 +122,15 @@ spec:
               forProvider:
                 description: ObjectParameters are the configurable fields of a Object.
                 properties:
+                  deletionPropagationPolicy:
+                    default: Background
+                    description: Deletion policy for created kubernetes object, defaults
+                      to Background
+                    enum:
+                    - Orphan
+                    - Background
+                    - Foreground
+                    type: string
                   manifest:
                     description: Raw JSON representation of the kubernetes object
                       to be created.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #342

When an `Object` resource is deleted, dependent resources (particularly Pods owned by Jobs) are not being properly cleaned up, resulting in orphaned Pods that remain in the cluster for a long time. In my experience it is about a week.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I followed the same procedure from the original issue with the current latest version of the provider (v1.2.1) and with the modified version from my fork. I validated that before the change Object deletion removed the Job but not its Pods, after the change Object deletion removed the Job and Pods.
