### PR TITLE
fix(security): update grpc to v.1.79.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	go.uber.org/zap v1.27.0
 	golang.org/x/oauth2 v0.27.0
 	golang.org/x/sync v0.18.0
-	google.golang.org/grpc v1.68.1
+	google.golang.org/grpc v1.79.3
 	k8s.io/api v0.33.0
 	k8s.io/apiextensions-apiserver v0.33.0
 	k8s.io/apimachinery v0.33.0


### PR DESCRIPTION
solves critical vulnerability CVE-2026-33186 in grpc-go.
Read [further information about the CVE](https://github.com/grpc/grpc-go/security/advisories/GHSA-p77j-4mvh-x3m3)
