### PR TITLE
ci: add codecov token for coverage report uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
         with:
           flags: unittests
           files: _output/tests/linux_amd64/coverage.txt
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   e2e-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description of your changes

in CI, adds token to codecov action, for uploading unit test coverage results. Protected branches require token per https://docs.codecov.com/docs/codecov-tokens#when-do-i-need-a-token

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

CI
[CI / unit-tests (pull_request)](https://github.com/crossplane-contrib/provider-kubernetes/actions/runs/25422462834/job/74567717207?pr=470) `Publish Unit Test Coverage` step

[contribution process]: https://git.io/fj2m9
