### PR TITLE
Add DeletionPropagationPolicy unit tests

### DIFF
--- a/internal/controller/cluster/object/object_test.go
+++ b/internal/controller/cluster/object/object_test.go
@@ -934,6 +934,78 @@ func TestDelete(t *testing.T) {
 				err: nil,
 			},
 		},
+		"SuccessWithForegroundPropagation": {
+			args: args{
+				mg: kubernetesObject(func(obj *v1alpha2.Object) {
+					obj.Spec.ForProvider.DeletionPropagationPolicy = metav1.DeletePropagationForeground
+				}),
+				client: resource.ClientApplicator{
+					Client: &test.MockClient{
+						MockDelete: func(_ context.Context, _ client.Object, opts ...client.DeleteOption) error {
+							do := &client.DeleteOptions{}
+							for _, o := range opts {
+								o.ApplyToDelete(do)
+							}
+							if do.PropagationPolicy == nil || *do.PropagationPolicy != metav1.DeletePropagationForeground {
+								t.Errorf("expected Foreground propagation policy, got %v", do.PropagationPolicy)
+							}
+							return nil
+						},
+					},
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		"SuccessWithOrphanPropagation": {
+			args: args{
+				mg: kubernetesObject(func(obj *v1alpha2.Object) {
+					obj.Spec.ForProvider.DeletionPropagationPolicy = metav1.DeletePropagationOrphan
+				}),
+				client: resource.ClientApplicator{
+					Client: &test.MockClient{
+						MockDelete: func(_ context.Context, _ client.Object, opts ...client.DeleteOption) error {
+							do := &client.DeleteOptions{}
+							for _, o := range opts {
+								o.ApplyToDelete(do)
+							}
+							if do.PropagationPolicy == nil || *do.PropagationPolicy != metav1.DeletePropagationOrphan {
+								t.Errorf("expected Orphan propagation policy, got %v", do.PropagationPolicy)
+							}
+							return nil
+						},
+					},
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		"SuccessWithBackgroundPropagation": {
+			args: args{
+				mg: kubernetesObject(func(obj *v1alpha2.Object) {
+					obj.Spec.ForProvider.DeletionPropagationPolicy = metav1.DeletePropagationBackground
+				}),
+				client: resource.ClientApplicator{
+					Client: &test.MockClient{
+						MockDelete: func(_ context.Context, _ client.Object, opts ...client.DeleteOption) error {
+							do := &client.DeleteOptions{}
+							for _, o := range opts {
+								o.ApplyToDelete(do)
+							}
+							if do.PropagationPolicy == nil || *do.PropagationPolicy != metav1.DeletePropagationBackground {
+								t.Errorf("expected Background propagation policy, got %v", do.PropagationPolicy)
+							}
+							return nil
+						},
+					},
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/controller/namespaced/object/object_test.go
+++ b/internal/controller/namespaced/object/object_test.go
@@ -936,6 +936,78 @@ func TestDelete(t *testing.T) {
 				err: nil,
 			},
 		},
+		"SuccessWithForegroundPropagation": {
+			args: args{
+				mg: kubernetesObject(func(obj *objv1alpha1.Object) {
+					obj.Spec.ForProvider.DeletionPropagationPolicy = metav1.DeletePropagationForeground
+				}),
+				client: resource.ClientApplicator{
+					Client: &test.MockClient{
+						MockDelete: func(_ context.Context, _ client.Object, opts ...client.DeleteOption) error {
+							do := &client.DeleteOptions{}
+							for _, o := range opts {
+								o.ApplyToDelete(do)
+							}
+							if do.PropagationPolicy == nil || *do.PropagationPolicy != metav1.DeletePropagationForeground {
+								t.Errorf("expected Foreground propagation policy, got %v", do.PropagationPolicy)
+							}
+							return nil
+						},
+					},
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		"SuccessWithOrphanPropagation": {
+			args: args{
+				mg: kubernetesObject(func(obj *objv1alpha1.Object) {
+					obj.Spec.ForProvider.DeletionPropagationPolicy = metav1.DeletePropagationOrphan
+				}),
+				client: resource.ClientApplicator{
+					Client: &test.MockClient{
+						MockDelete: func(_ context.Context, _ client.Object, opts ...client.DeleteOption) error {
+							do := &client.DeleteOptions{}
+							for _, o := range opts {
+								o.ApplyToDelete(do)
+							}
+							if do.PropagationPolicy == nil || *do.PropagationPolicy != metav1.DeletePropagationOrphan {
+								t.Errorf("expected Orphan propagation policy, got %v", do.PropagationPolicy)
+							}
+							return nil
+						},
+					},
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		"SuccessWithBackgroundPropagation": {
+			args: args{
+				mg: kubernetesObject(func(obj *objv1alpha1.Object) {
+					obj.Spec.ForProvider.DeletionPropagationPolicy = metav1.DeletePropagationBackground
+				}),
+				client: resource.ClientApplicator{
+					Client: &test.MockClient{
+						MockDelete: func(_ context.Context, _ client.Object, opts ...client.DeleteOption) error {
+							do := &client.DeleteOptions{}
+							for _, o := range opts {
+								o.ApplyToDelete(do)
+							}
+							if do.PropagationPolicy == nil || *do.PropagationPolicy != metav1.DeletePropagationBackground {
+								t.Errorf("expected Background propagation policy, got %v", do.PropagationPolicy)
+							}
+							return nil
+						},
+					},
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
### Description of your changes

Follow-up to #437. Adds unit tests for the new `deletionPropagationPolicy`
field, verifying each propagation value (Foreground, Orphan, Background)
is correctly forwarded via `DeleteOptions` to the Kubernetes API delete call.

Tests added for both cluster (`v1alpha2`) and namespaced (`v1alpha1`) controllers.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Unit tests added to `TestDelete` in both `internal/controller/cluster/object/object_test.go`
and `internal/controller/namespaced/object/object_test.go`. `make reviewable test` passes cleanly.

[contribution process]: https://git.io/fj2m9