### PR TITLE
Restore valid wildcards in renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -114,20 +114,20 @@
       "matchDatasources": ["go"],
       "groupName": "kubernetes patches",
       "matchUpdateTypes": ["patch", "digest"],
-      "matchPackageNames": ["k8s.io{/,}", "sigs.k8s.io{/,}"]
+      "matchPackageNames": ["k8s.io{/,}**", "sigs.k8s.io{/,}**"]
     },
     {
       // We want dedicated PRs for each minor and major bumps to kubernetes related
       // dependencies.
       "matchDatasources": ["go"],
       "matchUpdateTypes": ["major", "minor"],
-      "matchPackageNames": ["k8s.io{/,}", "sigs.k8s.io{/,}"]
+      "matchPackageNames": ["k8s.io{/,}**", "sigs.k8s.io{/,}**"]
     },
     {
       // We want dedicated PRs for each bump to non-kubernetes Go dependencies, but
       // only if there are known vulnerabilities in the current version.
       "matchDatasources": ["go"],
-      "matchPackageNames": ["!k8s.io{/,}", "!sigs.k8s.io{/,}"],
+      "matchPackageNames": ["!k8s.io{/,}**", "!sigs.k8s.io{/,}**"],
       "enabled": false,
       "matchUpdateTypes": ["major"]
     },
@@ -136,7 +136,7 @@
       // dependencies, but only if there are known vulnerabilities in the current
       // version.
       "matchDatasources": ["go"],
-      "matchPackageNames": ["!k8s.io{/,}", "!sigs.k8s.io{/,}"],
+      "matchPackageNames": ["!k8s.io{/,}**", "!sigs.k8s.io{/,}**"],
       "enabled": false,
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "groupName": "all non-major go dependencies"


### PR DESCRIPTION
### Description of your changes

The previous renovate config change removed more wildcards than necessary.  This restores the valid wildcards.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
renovate-config-validatror ran successfull


[contribution process]: https://git.io/fj2m9
