### PR TITLE
Observer Only without diff and extra SSA call

### DIFF
--- a/examples/cluster/object/object-csa-migration.yaml
+++ b/examples/cluster/object/object-csa-migration.yaml
@@ -14,7 +14,7 @@ metadata:
     # unpauses the MR to ensure it gets reconciled first with CSA.
     crossplane.io/paused: "true"
     uptest.upbound.io/post-assert-hook: testhooks/validate-ssa-migration.sh
-    uptest.upbound.io/timeout: "60"
+    uptest.upbound.io/timeout: "180"
 spec:
   forProvider:
     manifest:

--- a/examples/cluster/object/testhooks/validate-ssa-migration.sh
+++ b/examples/cluster/object/testhooks/validate-ssa-migration.sh
@@ -65,6 +65,30 @@ current_provider_args=$(${KUBECTL} get pods -A -l pkg.crossplane.io/provider=pro
 echo " ⛭ current provider args: $current_provider_args"
 echo " ☑️ Enabled server-side apply in provider..."
 
+# Wait for the provider to reconcile the object after SSA is enabled.
+# The provider needs time to observe the object, upgrade field managers, and
+# apply the desired state which removes the unwanted label and last-applied annotation.
+SSA_RECONCILE_TIMEOUT=60
+SSA_RECONCILE_START=$(date +%s)
+echo " ⏳ Waiting up to ${SSA_RECONCILE_TIMEOUT}s for SSA migration to complete..."
+while true; do
+  NOW=$(date +%s)
+  ELAPSED=$((NOW - SSA_RECONCILE_START))
+  if (( ELAPSED >= SSA_RECONCILE_TIMEOUT )); then
+    _pending_unwanted=$(${KUBECTL} -n default get service foo-service -o jsonpath='{.metadata.labels.unwanted}' 2>/dev/null || echo "")
+    _pending_ann=$(${KUBECTL} -n default get service foo-service -o jsonpath="{.metadata.annotations['kubectl.kubernetes.io/last-applied-configuration']}" 2>/dev/null || echo "")
+    echo " ❌ Timeout after ${SSA_RECONCILE_TIMEOUT}s. Still pending — unwanted label: '${_pending_unwanted}', annotation present: $( [ -n "$_pending_ann" ] && echo yes || echo no )"
+    break
+  fi
+  _unwanted=$(${KUBECTL} -n default get service foo-service -o jsonpath='{.metadata.labels.unwanted}' 2>/dev/null || echo "")
+  _annotation=$(${KUBECTL} -n default get service foo-service -o jsonpath="{.metadata.annotations['kubectl.kubernetes.io/last-applied-configuration']}" 2>/dev/null || echo "")
+  if [ -z "$_unwanted" ] && [ -z "$_annotation" ]; then
+    echo " ✅ SSA migration completed: unwanted label and annotation removed."
+    break
+  fi
+  sleep 2
+done
+
 # We have enabled the server-side apply
 # Validate last applied annotation is removed from the target object, as part of the SSA migration
 last_applied_annotation=$(${KUBECTL} get service foo-service -o jsonpath="{.metadata.annotations['kubectl.kubernetes.io/last-applied-configuration']}")

--- a/examples/namespaced/object/object-csa-migration.yaml
+++ b/examples/namespaced/object/object-csa-migration.yaml
@@ -15,7 +15,7 @@ metadata:
     # unpauses the MR to ensure it gets reconciled first with CSA.
     crossplane.io/paused: "true"
     uptest.upbound.io/post-assert-hook: testhooks/validate-ssa-migration.sh
-    uptest.upbound.io/timeout: "60"
+    uptest.upbound.io/timeout: "180"
 spec:
   forProvider:
     manifest:

--- a/examples/namespaced/object/testhooks/validate-ssa-migration.sh
+++ b/examples/namespaced/object/testhooks/validate-ssa-migration.sh
@@ -65,6 +65,30 @@ current_provider_args=$(${KUBECTL} get pods -A -l pkg.crossplane.io/provider=pro
 echo " ⛭ current provider args: $current_provider_args"
 echo " ☑️ Enabled server-side apply in provider..."
 
+# Wait for the provider to reconcile the object after SSA is enabled.
+# The provider needs time to observe the object, upgrade field managers, and
+# apply the desired state which removes the unwanted label and last-applied annotation.
+SSA_RECONCILE_TIMEOUT=60
+SSA_RECONCILE_START=$(date +%s)
+echo " ⏳ Waiting up to ${SSA_RECONCILE_TIMEOUT}s for SSA migration to complete..."
+while true; do
+  NOW=$(date +%s)
+  ELAPSED=$((NOW - SSA_RECONCILE_START))
+  if (( ELAPSED >= SSA_RECONCILE_TIMEOUT )); then
+    _pending_unwanted=$(${KUBECTL} -n default get service foo-service -o jsonpath='{.metadata.labels.unwanted}' 2>/dev/null || echo "")
+    _pending_ann=$(${KUBECTL} -n default get service foo-service -o jsonpath="{.metadata.annotations['kubectl.kubernetes.io/last-applied-configuration']}" 2>/dev/null || echo "")
+    echo " ❌ Timeout after ${SSA_RECONCILE_TIMEOUT}s. Still pending — unwanted label: '${_pending_unwanted}', annotation present: $( [ -n "$_pending_ann" ] && echo yes || echo no )"
+    break
+  fi
+  _unwanted=$(${KUBECTL} -n default get service foo-service -o jsonpath='{.metadata.labels.unwanted}' 2>/dev/null || echo "")
+  _annotation=$(${KUBECTL} -n default get service foo-service -o jsonpath="{.metadata.annotations['kubectl.kubernetes.io/last-applied-configuration']}" 2>/dev/null || echo "")
+  if [ -z "$_unwanted" ] && [ -z "$_annotation" ]; then
+    echo " ✅ SSA migration completed: unwanted label and annotation removed."
+    break
+  fi
+  sleep 2
+done
+
 # We have enabled the server-side apply
 # Validate last applied annotation is removed from the target object, as part of the SSA migration
 last_applied_annotation=$(${KUBECTL} -n default get service foo-service -o jsonpath="{.metadata.annotations['kubectl.kubernetes.io/last-applied-configuration']}")

--- a/internal/controller/cluster/object/object.go
+++ b/internal/controller/cluster/object/object.go
@@ -417,12 +417,9 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.Wrap(err, errGetObservedState)
 	}
 
-	var desiredState *unstructured.Unstructured
-	if desiredState, err = c.syncer.GetDesiredState(ctx, obj, manifest); err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, errGetDesiredState)
-	}
-
-	return c.handleObservation(ctx, obj, observedState, desiredState)
+	// Pass the raw manifest to handleObservation; desired state will only be
+	// computed there when the management policy requires it.
+	return c.handleObservation(ctx, obj, observedState, manifest)
 }
 
 func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
@@ -739,17 +736,36 @@ func (c *external) resolveReferencies(ctx context.Context, obj *v1alpha2.Object)
 	return nil
 }
 
-func (c *external) handleObservation(ctx context.Context, obj *v1alpha2.Object, last, desired *unstructured.Unstructured) (managed.ExternalObservation, error) {
+// handleObservation determines whether the managed resource is up-to-date.
+// For observe-only resources (management policies that do not include Create,
+// Update, or All), the desired state is never computed: those resources are
+// always considered up-to-date from a drift perspective. This avoids
+// unnecessary dry-run SSA requests for manifests that intentionally omit
+// fields such as spec (e.g. an Endpoints resource defined with only metadata).
+func (c *external) handleObservation(ctx context.Context, obj *v1alpha2.Object, observedState, manifest *unstructured.Unstructured) (managed.ExternalObservation, error) {
 	isUpToDate := false //nolint:staticcheck
 
-	if !sets.New[xpv1.ManagementAction](obj.GetManagementPolicies()...).
-		HasAny(xpv1.ManagementActionUpdate, xpv1.ManagementActionCreate, xpv1.ManagementActionAll) {
-		// Treated as up-to-date as we don't update or create the resource
+	isObserveOnly := !sets.New[xpv1.ManagementAction](obj.GetManagementPolicies()...).
+		HasAny(xpv1.ManagementActionUpdate, xpv1.ManagementActionCreate, xpv1.ManagementActionAll)
+
+	if isObserveOnly {
+		// Observe-only: no create/update will ever be issued, so there is no
+		// meaningful notion of drift. Treat the resource as up-to-date and skip
+		// the desired-state computation entirely (which for SSA involves a
+		// dry-run apply that can fail for intentionally sparse manifests).
 		isUpToDate = true
-	}
-	if last != nil && equality.Semantic.DeepEqual(last, desired) {
-		// Mark as up-to-date since last is equal to desired
-		isUpToDate = true
+	} else {
+		// Only compute desired state when we actually manage the resource.
+		// For SSA this performs a dry-run apply; skipping it for observe-only
+		// resources avoids failures on manifests that omit spec fields.
+		desiredState, err := c.syncer.GetDesiredState(ctx, obj, manifest)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, errGetDesiredState)
+		}
+		if observedState != nil && equality.Semantic.DeepEqual(observedState, desiredState) {
+			// Mark as up-to-date since observed matches desired
+			isUpToDate = true
+		}
 	}
 
 	if isUpToDate {

--- a/internal/controller/cluster/object/object_test.go
+++ b/internal/controller/cluster/object/object_test.go
@@ -629,12 +629,12 @@ func TestObserve(t *testing.T) {
 						}),
 					},
 				},
+				// GetDesiredStateFn is intentionally absent: for observe-only resources
+				// desired state must never be computed (e.g. SSA dry-run would fail for
+				// manifests that deliberately omit spec fields such as Endpoints).
 				syncer: &fake.ResourceSyncer{
 					GetObservedStateFn: func(ctx context.Context, obj *v1alpha2.Object, current *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 						return current, nil
-					},
-					GetDesiredStateFn: func(ctx context.Context, obj *v1alpha2.Object, manifest *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-						return manifest, nil
 					},
 				},
 			},

--- a/internal/controller/namespaced/object/object.go
+++ b/internal/controller/namespaced/object/object.go
@@ -418,12 +418,9 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.Wrap(err, errGetObservedState)
 	}
 
-	var desiredState *unstructured.Unstructured
-	if desiredState, err = c.syncer.GetDesiredState(ctx, obj, manifest); err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, errGetDesiredState)
-	}
-
-	return c.handleObservation(ctx, obj, observedState, desiredState)
+	// Pass the raw manifest to handleObservation; desired state will only be
+	// computed there when the management policy requires it.
+	return c.handleObservation(ctx, obj, observedState, manifest)
 }
 
 func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
@@ -740,17 +737,36 @@ func (c *external) resolveReferencies(ctx context.Context, obj *v1alpha1.Object)
 	return nil
 }
 
-func (c *external) handleObservation(ctx context.Context, obj *v1alpha1.Object, last, desired *unstructured.Unstructured) (managed.ExternalObservation, error) {
+// handleObservation determines whether the managed resource is up-to-date.
+// For observe-only resources (management policies that do not include Create,
+// Update, or All), the desired state is never computed: those resources are
+// always considered up-to-date from a drift perspective. This avoids
+// unnecessary dry-run SSA requests for manifests that intentionally omit
+// fields such as spec (e.g. an Endpoints resource defined with only metadata).
+func (c *external) handleObservation(ctx context.Context, obj *v1alpha1.Object, observedState, manifest *unstructured.Unstructured) (managed.ExternalObservation, error) {
 	isUpToDate := false //nolint:staticcheck
 
-	if !sets.New[xpv1.ManagementAction](obj.GetManagementPolicies()...).
-		HasAny(xpv1.ManagementActionUpdate, xpv1.ManagementActionCreate, xpv1.ManagementActionAll) {
-		// Treated as up-to-date as we don't update or create the resource
+	isObserveOnly := !sets.New[xpv1.ManagementAction](obj.GetManagementPolicies()...).
+		HasAny(xpv1.ManagementActionUpdate, xpv1.ManagementActionCreate, xpv1.ManagementActionAll)
+
+	if isObserveOnly {
+		// Observe-only: no create/update will ever be issued, so there is no
+		// meaningful notion of drift. Treat the resource as up-to-date and skip
+		// the desired-state computation entirely (which for SSA involves a
+		// dry-run apply that can fail for intentionally sparse manifests).
 		isUpToDate = true
-	}
-	if last != nil && equality.Semantic.DeepEqual(last, desired) {
-		// Mark as up-to-date since last is equal to desired
-		isUpToDate = true
+	} else {
+		// Only compute desired state when we actually manage the resource.
+		// For SSA this performs a dry-run apply; skipping it for observe-only
+		// resources avoids failures on manifests that omit spec fields.
+		desiredState, err := c.syncer.GetDesiredState(ctx, obj, manifest)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, errGetDesiredState)
+		}
+		if observedState != nil && equality.Semantic.DeepEqual(observedState, desiredState) {
+			// Mark as up-to-date since observed matches desired
+			isUpToDate = true
+		}
 	}
 
 	if isUpToDate {

--- a/internal/controller/namespaced/object/object_test.go
+++ b/internal/controller/namespaced/object/object_test.go
@@ -631,12 +631,12 @@ func TestObserve(t *testing.T) {
 						}),
 					},
 				},
+				// GetDesiredStateFn is intentionally absent: for observe-only resources
+				// desired state must never be computed (e.g. SSA dry-run would fail for
+				// manifests that deliberately omit spec fields such as Endpoints).
 				syncer: &fake.ResourceSyncer{
 					GetObservedStateFn: func(ctx context.Context, obj *objv1alpha1.Object, current *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 						return current, nil
-					},
-					GetDesiredStateFn: func(ctx context.Context, obj *objv1alpha1.Object, manifest *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-						return manifest, nil
 					},
 				},
 			},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Fix Observe mode SSA validation failure for sparse manifests in both namespaced and cluster scopes.

When `managementPolicies: [Observe]` is set and SSA is enabled (`--enable-beta-server-side-apply`), the controller was unconditionally calling `GetDesiredState` during reconcile even for observe-only resources. For SSA, `GetDesiredState` performs a **dry-run server-side apply** against the Kubernetes API. This dry-run fails for manifests that intentionally omit `spec` — for example an `Endpoints` resource defined with only `apiVersion`, `kind`, and `metadata`.

The fix follows the existing structure of `handleObservation`, which already short-circuits with `isUpToDate = true` for observe-only resources. The desired state computation is moved inside `handleObservation` and is now only performed when the management policy actually requires managing the resource (i.e. includes `Create`, `Update`, or `All`).

**Changes:**
- `Observe()`: removed the unconditional `GetDesiredState` call; passes the raw `manifest` to `handleObservation` instead of a pre-computed desired state
- `handleObservation()`: computes desired state lazily — only when not observe-only. For observe-only resources, the function returns `isUpToDate = true` immediately, skipping any API interaction
- Tests (`object_test.go`): the `"Observe Only - up to date by default"` test case no longer sets `GetDesiredStateFn`. Because a nil function panics if called, this acts as a live assertion that `GetDesiredState` is never invoked for observe-only resources
- Both **namespaced** and **cluster** scopes are fixed identically

Fixes #431 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- Existing unit tests updated to assert `GetDesiredState` is never called for observe-only resources (nil `GetDesiredStateFn` panics on invocation — test passing proves it is not called)
- Manually reproduced with an `Endpoints` object CR using only `apiVersion`, `kind`, and `metadata` in `forProvider.manifest` with SSA enabled and `managementPolicies: [Observe]` — confirms the controller no longer errors during reconcile
- All existing `TestObserve` cases continue to pass for both namespaced and cluster scopes, confirming non-observe-only flows are unaffected

[contribution process]: https://git.io/fj2m9
