### PR TITLE
test(ssa): extract stripAPIRootPrefix helper and unit-test it

### DIFF
--- a/pkg/kube/client/ssa/cache/extractor/caching_unstructured_extractor.go
+++ b/pkg/kube/client/ssa/cache/extractor/caching_unstructured_extractor.go
@@ -78,14 +78,24 @@ func discoveryPaths(ctx context.Context, rc rest.Interface) (map[string]OpenAPIG
 		if err != nil {
 			return nil, nil, err
 		}
-		oapiGV.ServerRelativeURL = strings.TrimPrefix(oapiGV.ServerRelativeURL, rootPrefix)
-		useClientPrefix := strings.HasPrefix(oapiGV.ServerRelativeURL, "/openapi/v3")
+		normalized, useClientPrefix := stripAPIRootPrefix(oapiGV, rootPrefix)
 		etag := parse.Query().Get("hash")
-		oapiPathsToGV[path] = newCustomOAPIGroupVersion(rc, oapiGV, useClientPrefix)
+		oapiPathsToGV[path] = newCustomOAPIGroupVersion(rc, normalized, useClientPrefix)
 		oapiPathsToETags[path] = etag
 
 	}
 	return oapiPathsToGV, oapiPathsToETags, nil
+}
+
+// stripAPIRootPrefix removes the API server's root path prefix from an OpenAPI
+// v3 discovery entry's ServerRelativeURL so it can be matched against the
+// canonical "/openapi/v3" prefix. It reports whether that prefix now matches -
+// i.e. whether the schema fetch should build the URL via the REST client's
+// base path (AbsPath) rather than issuing the raw server-relative URL. When
+// the API server is served at the root (rootPrefix is empty) this is a no-op.
+func stripAPIRootPrefix(oapiGV handler3.OpenAPIV3DiscoveryGroupVersion, rootPrefix string) (handler3.OpenAPIV3DiscoveryGroupVersion, bool) {
+	oapiGV.ServerRelativeURL = strings.TrimPrefix(oapiGV.ServerRelativeURL, rootPrefix)
+	return oapiGV, strings.HasPrefix(oapiGV.ServerRelativeURL, "/openapi/v3")
 }
 
 // getParserForGV fetches the *GVKParser for the given GroupVersion.

--- a/pkg/kube/client/ssa/cache/extractor/caching_unstructured_extractor_test.go
+++ b/pkg/kube/client/ssa/cache/extractor/caching_unstructured_extractor_test.go
@@ -108,6 +108,21 @@ type mockAPIServer struct {
 	server        *httptest.Server
 	discoveryData handler3.OpenAPIV3Discovery
 	rootPrefix    string
+
+	mu             sync.Mutex
+	requestedPaths []string
+}
+
+func (mas *mockAPIServer) recordRequestPath(path string) {
+	mas.mu.Lock()
+	defer mas.mu.Unlock()
+	mas.requestedPaths = append(mas.requestedPaths, path)
+}
+
+func (mas *mockAPIServer) requestPaths() []string {
+	mas.mu.Lock()
+	defer mas.mu.Unlock()
+	return append([]string(nil), mas.requestedPaths...)
 }
 
 var discoveryDataInitial = map[string]string{
@@ -140,6 +155,7 @@ func newMockAPIServerWithRootPrefix(rootPrefix string) (*mockAPIServer, error) {
 	as.setDiscoveryData(discoveryDataInitial)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		as.recordRequestPath(r.URL.Path)
 		path := strings.TrimPrefix(r.URL.Path, rootPrefix)
 		switch {
 		case strings.HasPrefix(path, "/openapi/v3/api"):
@@ -321,7 +337,8 @@ func TestDiscovery(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			paths, etags, err := discoveryPaths(context.TODO(), dc.RESTClient())
+			ctx := t.Context()
+			paths, etags, err := discoveryPaths(ctx, dc.RESTClient())
 			if diff := cmp.Diff(tt.want.err, err, test.EquateErrors()); diff != "" {
 				t.Fatalf("discovery error (-want +got):\n%s", diff)
 			}
@@ -335,28 +352,79 @@ func TestDiscovery(t *testing.T) {
 					t.Fatalf("wanted path %s not found in discovery", wp)
 				}
 
-				// discoveryPaths must strip any root path prefix from the
-				// ServerRelativeURL so that the value hits the "/openapi/v3"
-				// prefix check and the client uses AbsPath (which prepends
-				// the client's own base path) rather than issuing the raw
-				// server-relative URL directly.
-				concrete, ok := oapiGV.(*customOAPIGroupVersion)
-				if !ok {
-					t.Fatalf("expected *customOAPIGroupVersion, got %T", oapiGV)
-				}
-				if !strings.HasPrefix(concrete.item.ServerRelativeURL, "/openapi/v3") {
-					t.Fatalf("ServerRelativeURL for %s should start with /openapi/v3 after prefix stripping, got %q", wp, concrete.item.ServerRelativeURL)
-				}
-				if !concrete.useClientPrefix {
-					t.Fatalf("useClientPrefix should be true for %s after prefix stripping, got false", wp)
-				}
-
-				// End-to-end sanity: with the prefix correctly handled, the
-				// schema fetch and parser build should succeed against the
-				// mock server for both the default and prefixed cases.
-				if _, err := newParserFromOpenAPIGroupVersion(context.TODO(), oapiGV); err != nil {
+				// Round-trip the schema fetch through the returned
+				// OpenAPIGroupVersion. This exercises the whole flow -
+				// discovery, URL normalization and schema retrieval -
+				// against the mock server for both the default and
+				// prefixed cases.
+				if _, err := newParserFromOpenAPIGroupVersion(ctx, oapiGV); err != nil {
 					t.Fatalf("unexpected error building parser for %s (rootPrefix=%q): %v", wp, tt.rootPrefix, err)
 				}
+			}
+
+			// Every request that hit the mock server (discovery + each
+			// per-GV schema fetch) must arrive with the configured
+			// rootPrefix intact, i.e. the client rebuilt the full URL
+			// correctly from the normalized ServerRelativeURL and never
+			// dropped or double-stamped the prefix.
+			wantPathPrefix := tt.rootPrefix + "/openapi/v3"
+			for _, got := range mockK8sAPIServer.requestPaths() {
+				if !strings.HasPrefix(got, wantPathPrefix) {
+					t.Fatalf("request %q did not start with expected prefix %q (rootPrefix=%q)", got, wantPathPrefix, tt.rootPrefix)
+				}
+			}
+		})
+	}
+}
+
+func TestStripAPIRootPrefix(t *testing.T) {
+	tests := []struct {
+		name                string
+		input               handler3.OpenAPIV3DiscoveryGroupVersion
+		rootPrefix          string
+		wantURL             string
+		wantUseClientPrefix bool
+	}{
+		{
+			name:                "NoPrefix",
+			input:               handler3.OpenAPIV3DiscoveryGroupVersion{ServerRelativeURL: "/openapi/v3/apis/apps/v1?hash=111"},
+			rootPrefix:          "",
+			wantURL:             "/openapi/v3/apis/apps/v1?hash=111",
+			wantUseClientPrefix: true,
+		},
+		{
+			// Regression coverage: an API server exposed behind a URL
+			// path prefix returns ServerRelativeURL values that include
+			// the prefix. stripAPIRootPrefix must remove that prefix so
+			// the "/openapi/v3" check matches and the client uses AbsPath
+			// (which prepends its own base path) rather than issuing the
+			// raw, already-prefixed URL directly.
+			name:                "WithPrefix",
+			input:               handler3.OpenAPIV3DiscoveryGroupVersion{ServerRelativeURL: "/k8s/openapi/v3/apis/apps/v1?hash=111"},
+			rootPrefix:          "/k8s",
+			wantURL:             "/openapi/v3/apis/apps/v1?hash=111",
+			wantUseClientPrefix: true,
+		},
+		{
+			// Safety: an entry that legitimately does not start with
+			// /openapi/v3 (either because the server returned an
+			// absolute-looking URL or because our rootPrefix guess was
+			// wrong) must not be flagged for AbsPath-style URL rebuilding.
+			name:                "NoOpenAPIv3Prefix",
+			input:               handler3.OpenAPIV3DiscoveryGroupVersion{ServerRelativeURL: "/some/other/path"},
+			rootPrefix:          "",
+			wantURL:             "/some/other/path",
+			wantUseClientPrefix: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotGV, gotUseClientPrefix := stripAPIRootPrefix(tt.input, tt.rootPrefix)
+			if gotGV.ServerRelativeURL != tt.wantURL {
+				t.Errorf("ServerRelativeURL = %q, want %q", gotGV.ServerRelativeURL, tt.wantURL)
+			}
+			if gotUseClientPrefix != tt.wantUseClientPrefix {
+				t.Errorf("useClientPrefix = %v, want %v", gotUseClientPrefix, tt.wantUseClientPrefix)
 			}
 		})
 	}


### PR DESCRIPTION
### Description of your changes

Follow-up to #507 to address @bobh66's [review comment](https://github.com/crossplane-contrib/provider-kubernetes/pull/507#discussion_r3516084748) that landed after the merge.

The `TestDiscovery/DiscoveryWithRootPathPrefix` subtest that shipped with #507 reached into `*customOAPIGroupVersion` internals via a type assertion to verify the OpenAPI v3 discovery URL had been normalized correctly. That's a smell — the test knows too much about the unexported implementation.

This PR:

- Extracts the root-prefix normalization out of `discoveryPaths` into a small package helper, `stripAPIRootPrefix(handler3.OpenAPIV3DiscoveryGroupVersion, rootPrefix) (handler3.OpenAPIV3DiscoveryGroupVersion, bool)`.
- Adds `TestStripAPIRootPrefix`, which unit-tests the helper directly across the "served at the root", "behind a `/k8s` prefix", and "unexpected URL" cases. This is where the regression assertion now lives, and I've confirmed it fails if the trimming is removed.
- Drops the type-assertion / unexported-field peek out of `TestDiscovery`. Both subtests now just round-trip through discovery + parser construction against the mock server, so the test only touches public behaviour.
- Switches the discovery subtests to `t.Context()` (Go 1.24+).
- Has the mock API server record every request path it serves, and each `TestDiscovery` subtest now asserts that every client-go request (discovery + per-GV schema fetches) arrived with the configured `rootPrefix` intact — i.e. the client rebuilt the full URL correctly from the normalized `ServerRelativeURL` and never dropped or double-stamped the prefix. This is complementary coverage on top of the direct `stripAPIRootPrefix` test.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- `make reviewable test` (locally, on Go 1.26.4).
- Manually verified `TestStripAPIRootPrefix/WithPrefix` fails if the `strings.TrimPrefix(..., rootPrefix)` line is removed from `stripAPIRootPrefix`.

[contribution process]: https://git.io/fj2m9
