### PR TITLE
Log a diff when Object drift is detected at debug level

### DIFF
--- a/internal/controller/cluster/object/object.go
+++ b/internal/controller/cluster/object/object.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/google/cel-go/cel"
 	celtypes "github.com/google/cel-go/common/types"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -777,6 +778,8 @@ func (c *external) handleObservation(ctx context.Context, obj *v1alpha2.Object, 
 			ConnectionDetails: cd,
 		}, nil
 	}
+
+	c.logger.Debug("Not up to date", "diff", cmp.Diff(last, desired))
 
 	return managed.ExternalObservation{
 		ResourceExists:   true,

--- a/internal/controller/cluster/object/object_test.go
+++ b/internal/controller/cluster/object/object_test.go
@@ -379,6 +379,32 @@ func TestObserve(t *testing.T) {
 				err: nil,
 			},
 		},
+		"NotUpToDateNoObservedState": {
+			args: args{
+				mg: kubernetesObject(),
+				client: resource.ClientApplicator{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+							*obj.(*unstructured.Unstructured) = *externalResource()
+							return nil
+						}),
+					},
+				},
+				syncer: &fake.ResourceSyncer{
+					GetObservedStateFn: func(ctx context.Context, obj *v1alpha2.Object, current *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+						// e.g. no last-applied-configuration annotation yet.
+						return nil, nil
+					},
+					GetDesiredStateFn: func(ctx context.Context, obj *v1alpha2.Object, manifest *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+						return manifest, nil
+					},
+				},
+			},
+			want: want{
+				out: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: false},
+				err: nil,
+			},
+		},
 		"UpToDate": {
 			args: args{
 				mg: kubernetesObject(),

--- a/internal/controller/namespaced/object/object.go
+++ b/internal/controller/namespaced/object/object.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/google/cel-go/cel"
 	celtypes "github.com/google/cel-go/common/types"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -778,6 +779,8 @@ func (c *external) handleObservation(ctx context.Context, obj *v1alpha1.Object, 
 			ConnectionDetails: cd,
 		}, nil
 	}
+
+	c.logger.Debug("Not up to date", "diff", cmp.Diff(last, desired))
 
 	return managed.ExternalObservation{
 		ResourceExists:   true,

--- a/internal/controller/namespaced/object/object_test.go
+++ b/internal/controller/namespaced/object/object_test.go
@@ -380,6 +380,32 @@ func TestObserve(t *testing.T) {
 				err: nil,
 			},
 		},
+		"NotUpToDateNoObservedState": {
+			args: args{
+				mg: kubernetesObject(),
+				client: resource.ClientApplicator{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+							*obj.(*unstructured.Unstructured) = *externalResource()
+							return nil
+						}),
+					},
+				},
+				syncer: &fake.ResourceSyncer{
+					GetObservedStateFn: func(ctx context.Context, obj *objv1alpha1.Object, current *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+						// e.g. no last-applied-configuration annotation yet.
+						return nil, nil
+					},
+					GetDesiredStateFn: func(ctx context.Context, obj *objv1alpha1.Object, manifest *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+						return manifest, nil
+					},
+				},
+			},
+			want: want{
+				out: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: false},
+				err: nil,
+			},
+		},
 		"UpToDate": {
 			args: args{
 				mg: kubernetesObject(),


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

When the Object controller decides a managed resource is not up-to-date, it
previously logged nothing at Debug level about *why* — only that it wasn't
up-to-date. A user on this issue reported that persistent drift (in their
case caused by an empty-string label in the manifest) was driving frequent
reconciliation and high CPU usage, and that they had no way to see the root
cause from the provider's debug logs, forcing trial-and-error to diagnose it.

This PR adds a Debug-level log line in `handleObservation` (both the cluster
and namespaced Object controllers) that includes a structural diff (via
`github.com/google/go-cmp`, already a direct dependency) between the observed
and desired state whenever the resource is found not up-to-date. This is a
diagnostics-only change — it does not alter `ExternalObservation` values,
reconcile cadence, or backoff behavior, and does not by itself address the
reconciliation-frequency/CPU-usage question raised in the issue (that would
need separate design discussion). It only makes it possible to root-cause
persistent drift from existing debug logs.

Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Ran `go build ./...` (clean) and
`go test ./internal/controller/cluster/object/... ./internal/controller/namespaced/object/...`
(all tests pass), including a new `NotUpToDateNoObservedState` test case
added to both packages' `TestObserve` table that drives `handleObservation`
with a nil observed state to exercise the new log call and confirm it does
not panic. Also ran `go vet` and `gofmt -l` on the changed files (clean),
and `make lint` (golangci-lint), which reports no new findings in either
changed file — the pre-existing failures it reports are in unrelated files
and predate this change.

[contribution process]: https://git.io/fj2m9

Fixes #422