### PR TITLE
Honor proxy-url from kubeconfig cluster config

### DIFF
--- a/pkg/kube/client/client.go
+++ b/pkg/kube/client/client.go
@@ -15,6 +15,8 @@ package client
 
 import (
 	"context"
+	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -47,6 +49,7 @@ const (
 	errInjectAWSCredentials      = "failed to wrap REST client with AWS credentials"
 	errExtractNebiusCredentials  = "failed to extract Nebius service account credentials"
 	errInjectNebiusCredentials   = "failed to wrap REST client with Nebius service account credentials"
+	errParseProxyURL             = "cannot parse proxy URL from kubeconfig"
 )
 
 // A Builder creates Kubernetes clients and REST configs for a given provider
@@ -255,6 +258,14 @@ func fromAPIConfig(c *api.Config) (*rest.Config, error) {
 			KeyData:    user.ClientKeyData,
 			CAData:     cluster.CertificateAuthorityData,
 		},
+	}
+
+	if cluster.ProxyURL != "" {
+		proxyURL, err := url.Parse(cluster.ProxyURL)
+		if err != nil {
+			return nil, errors.Wrap(err, errParseProxyURL)
+		}
+		config.Proxy = http.ProxyURL(proxyURL)
 	}
 
 	// NOTE(tnthornton): these values match the burst and QPS values in kubectl.

--- a/pkg/kube/client/client_test.go
+++ b/pkg/kube/client/client_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 The Crossplane Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+)
+
+func TestFromAPIConfigProxy(t *testing.T) {
+	apiConfig := func(proxyURL string) *api.Config {
+		return &api.Config{
+			CurrentContext: "test",
+			Contexts: map[string]*api.Context{
+				"test": {Cluster: "test-cluster", AuthInfo: "test-user"},
+			},
+			Clusters: map[string]*api.Cluster{
+				"test-cluster": {Server: "https://example.org:6443", ProxyURL: proxyURL},
+			},
+			AuthInfos: map[string]*api.AuthInfo{
+				"test-user": {},
+			},
+		}
+	}
+
+	type args struct {
+		config *api.Config
+	}
+	type want struct {
+		proxyURL string
+		err      error
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"ProxyURLSet": {
+			args: args{
+				config: apiConfig("http://proxy.example.org:3128"),
+			},
+			want: want{
+				proxyURL: "http://proxy.example.org:3128",
+			},
+		},
+		"ProxyURLUnset": {
+			args: args{
+				config: apiConfig(""),
+			},
+			want: want{},
+		},
+		"ProxyURLInvalid": {
+			args: args{
+				config: apiConfig("://invalid"),
+			},
+			want: want{
+				err: errors.Wrap(&url.Error{Op: "parse", URL: "://invalid", Err: errors.New("missing protocol scheme")}, errParseProxyURL),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			config, err := fromAPIConfig(tc.args.config)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Fatalf("fromAPIConfig() error: -want +got\n%s", diff)
+			}
+			if err != nil {
+				return
+			}
+
+			gotProxyURL := ""
+			if config.Proxy != nil {
+				u, proxyErr := config.Proxy(&http.Request{URL: &url.URL{Scheme: "https", Host: "example.org:6443"}})
+				if proxyErr != nil {
+					t.Fatalf("unexpected error from proxy func: %v", proxyErr)
+				}
+				if u != nil {
+					gotProxyURL = u.String()
+				}
+			}
+			if diff := cmp.Diff(tc.want.proxyURL, gotProxyURL); diff != "" {
+				t.Fatalf("fromAPIConfig() proxy URL: -want +got\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

`fromAPIConfig` builds the `rest.Config` from the kubeconfig by hand and silently dropped `cluster.ProxyURL`, so target clusters that are only reachable through a proxy could not be managed. This parses the proxy URL up front with explicit error handling and sets `config.Proxy = http.ProxyURL(u)`.

This follows the approach of the closed PR #387 by @shepses (production-tested by users in that thread), restructured per @turkenf's review there: the URL is parsed and validated outside the struct literal instead of an inline closure, so an invalid `proxy-url` surfaces as an error instead of failing at request time.

Fixes #347

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

New table-driven unit test for `fromAPIConfig` covering proxy-url set (proxy func returns the URL), unset (no proxy configured), and invalid (wrapped parse error). `golangci-lint` clean, `go build`/`go vet`/`go test` green locally.

[contribution process]: https://git.io/fj2m9
