### PR TITLE
Do not block Object deletion on failed connection details

### DIFF
--- a/internal/controller/cluster/object/object.go
+++ b/internal/controller/cluster/object/object.go
@@ -766,9 +766,17 @@ func (c *external) handleObservation(ctx context.Context, obj *v1alpha2.Object, 
 			obj.Status.SetConditions(xpv2.Available())
 		}
 
-		cd, err := connectionDetails(ctx, c.client.Client, obj.Spec.ConnectionDetails)
-		if err != nil {
-			return managed.ExternalObservation{}, errors.Wrap(err, errGetConnectionDetails)
+		var cd managed.ConnectionDetails
+		if !meta.WasDeleted(obj) {
+			// Connection details are not collected while the object is being
+			// deleted: a broken connection detail reference would block the
+			// deletion path, and the connection secret is owner-referenced to
+			// the Object, so it is garbage collected with it anyway.
+			var err error
+			cd, err = connectionDetails(ctx, c.client.Client, obj.Spec.ConnectionDetails)
+			if err != nil {
+				return managed.ExternalObservation{}, errors.Wrap(err, errGetConnectionDetails)
+			}
 		}
 
 		return managed.ExternalObservation{

--- a/internal/controller/cluster/object/object_test.go
+++ b/internal/controller/cluster/object/object_test.go
@@ -617,6 +617,53 @@ func TestObserve(t *testing.T) {
 				err: errors.Wrap(errors.Wrap(errBoom, errGetObject), errGetConnectionDetails),
 			},
 		},
+		"SkipConnectionDetailsIfObjectWasDeleted": {
+			args: args{
+				mg: kubernetesObject(func(obj *v1alpha2.Object) {
+					obj.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+					obj.Spec.ConnectionDetails = []v1alpha2.ConnectionDetail{
+						{
+							ObjectReference: corev1.ObjectReference{
+								Kind:       "Secret",
+								Namespace:  testNamespace,
+								Name:       testSecretName,
+								APIVersion: "v1",
+								FieldPath:  "data.db-password",
+							},
+							ToConnectionSecretKey: "password",
+						},
+					}
+				}),
+				client: resource.ClientApplicator{
+					Client: &test.MockClient{
+						MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+							switch key.Name {
+							case externalResourceName:
+								*obj.(*unstructured.Unstructured) = *externalResource()
+							case testSecretName:
+								return errBoom
+							}
+							return nil
+						},
+					},
+				},
+				syncer: &fake.ResourceSyncer{
+					GetObservedStateFn: func(ctx context.Context, obj *v1alpha2.Object, current *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+						return current, nil
+					},
+					GetDesiredStateFn: func(ctx context.Context, obj *v1alpha2.Object, manifest *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+						return manifest, nil
+					},
+				},
+			},
+			want: want{
+				out: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: true,
+				},
+				err: nil,
+			},
+		},
 		"Observe Only - up to date by default": {
 			args: args{
 				mg: kubernetesObject(func(obj *v1alpha2.Object) {

--- a/internal/controller/namespaced/object/object.go
+++ b/internal/controller/namespaced/object/object.go
@@ -767,9 +767,17 @@ func (c *external) handleObservation(ctx context.Context, obj *v1alpha1.Object, 
 			obj.Status.SetConditions(xpv2.Available())
 		}
 
-		cd, err := connectionDetails(ctx, c.client.Client, obj.Spec.ConnectionDetails)
-		if err != nil {
-			return managed.ExternalObservation{}, errors.Wrap(err, errGetConnectionDetails)
+		var cd managed.ConnectionDetails
+		if !meta.WasDeleted(obj) {
+			// Connection details are not collected while the object is being
+			// deleted: a broken connection detail reference would block the
+			// deletion path, and the connection secret is owner-referenced to
+			// the Object, so it is garbage collected with it anyway.
+			var err error
+			cd, err = connectionDetails(ctx, c.client.Client, obj.Spec.ConnectionDetails)
+			if err != nil {
+				return managed.ExternalObservation{}, errors.Wrap(err, errGetConnectionDetails)
+			}
 		}
 
 		return managed.ExternalObservation{

--- a/internal/controller/namespaced/object/object_test.go
+++ b/internal/controller/namespaced/object/object_test.go
@@ -618,6 +618,53 @@ func TestObserve(t *testing.T) {
 				err: errors.Wrap(errors.Wrap(errBoom, errGetObject), errGetConnectionDetails),
 			},
 		},
+		"SkipConnectionDetailsIfObjectWasDeleted": {
+			args: args{
+				mg: kubernetesObject(func(obj *objv1alpha1.Object) {
+					obj.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+					obj.Spec.ConnectionDetails = []objv1alpha1.ConnectionDetail{
+						{
+							ObjectReference: corev1.ObjectReference{
+								Kind:       "Secret",
+								Namespace:  testNamespace,
+								Name:       testSecretName,
+								APIVersion: "v1",
+								FieldPath:  "data.db-password",
+							},
+							ToConnectionSecretKey: "password",
+						},
+					}
+				}),
+				client: resource.ClientApplicator{
+					Client: &test.MockClient{
+						MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+							switch key.Name {
+							case externalResourceName:
+								*obj.(*unstructured.Unstructured) = *externalResource()
+							case testSecretName:
+								return errBoom
+							}
+							return nil
+						},
+					},
+				},
+				syncer: &fake.ResourceSyncer{
+					GetObservedStateFn: func(ctx context.Context, obj *objv1alpha1.Object, current *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+						return current, nil
+					},
+					GetDesiredStateFn: func(ctx context.Context, obj *objv1alpha1.Object, manifest *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+						return manifest, nil
+					},
+				},
+			},
+			want: want{
+				out: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: true,
+				},
+				err: nil,
+			},
+		},
 		"Observe Only - up to date by default": {
 			args: args{
 				mg: kubernetesObject(func(obj *objv1alpha1.Object) {


### PR DESCRIPTION
### Description of your changes

An `Object` whose `spec.connectionDetails` references a resource that cannot be read could never be deleted: `handleObservation` hard-failed on the `connectionDetails()` error before the deletion path could run, so `Observe` kept erroring and the delete never happened.

This skips collecting connection details when the `Object` is being deleted (`meta.WasDeleted`), in both the cluster-scoped and namespaced controllers, mirroring the existing guard for reference resolution from f5769b4.

This is safe even when the read failure is transient: the connection secret carries a controller `ownerReference` to the `Object` (`ConnectionSecretFor`/`LocalConnectionSecretFor` in crossplane-runtime), so it is garbage collected together with the `Object` and nothing can leak by skipping the read during deletion.

Fixes #345

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

New `TestObserve/SkipConnectionDetailsIfObjectWasDeleted` regression case in both controllers: a deleted `Object` with a failing connection-detail read now observes successfully (previously returned the wrapped error). Full package test suites, `golangci-lint`, `go build`/`go vet` green locally.

[contribution process]: https://git.io/fj2m9
