### PR TITLE
Redact Secret data from debug logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/crossplane/crossplane-runtime/v2 v2.3.3
 	github.com/crossplane/crossplane-tools v0.0.0-20260715161912-60e57f817ad1
 	github.com/crossplane/crossplane/apis/v2 v2.3.3
+	github.com/go-logr/logr v1.4.3
 	github.com/google/cel-go v0.29.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
@@ -76,7 +77,6 @@ require (
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v1.0.0 // indirect
 	github.com/go-openapi/jsonreference v1.0.0 // indirect

--- a/internal/controller/cluster/object/object.go
+++ b/internal/controller/cluster/object/object.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/google/cel-go/cel"
 	celtypes "github.com/google/cel-go/common/types"
 	"github.com/pkg/errors"
@@ -374,7 +375,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.New(errNotKubernetesObject)
 	}
 
-	c.logger.Debug("Observing", "resource", obj)
+	c.logger.Debug("Observing", "resource", loggable(obj))
 
 	if !meta.WasDeleted(obj) {
 		// If the object is not being deleted, we need to resolve references
@@ -435,7 +436,7 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalCreation{}, errors.New(errNotKubernetesObject)
 	}
 
-	c.logger.Debug("Creating", "resource", obj)
+	c.logger.Debug("Creating", "resource", loggable(obj))
 
 	res, err := parseManifest(obj)
 	if err != nil {
@@ -455,7 +456,7 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalUpdate{}, errors.New(errNotKubernetesObject)
 	}
 
-	c.logger.Debug("Updating", "resource", obj)
+	c.logger.Debug("Updating", "resource", loggable(obj))
 
 	res, err := parseManifest(obj)
 	if err != nil {
@@ -481,7 +482,7 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 		PropagationPolicy: &propagationPolicy,
 	}
 
-	c.logger.Debug("Deleting", "resource", obj, "propagationPolicy", obj.Spec.ForProvider.DeletionPropagationPolicy)
+	c.logger.Debug("Deleting", "resource", loggable(obj), "propagationPolicy", obj.Spec.ForProvider.DeletionPropagationPolicy)
 
 	res, err := parseManifest(obj)
 	if err != nil {
@@ -517,6 +518,76 @@ func parseManifest(obj *v1alpha2.Object) (*unstructured.Unstructured, error) {
 	return r, nil
 }
 
+// loggable wraps an Object for debug logging so that Secret data is redacted
+// lazily, only when the log line is actually emitted.
+func loggable(obj *v1alpha2.Object) logr.Marshaler {
+	return loggableObject{obj: obj}
+}
+
+type loggableObject struct {
+	obj *v1alpha2.Object
+}
+
+// MarshalLog implements logr.Marshaler. It returns a copy of the Object with
+// the data and stringData of a wrapped v1 Secret manifest redacted in both
+// the desired manifest and the observed state, so that secret values do not
+// end up in provider logs. The deeper handling of secret values persisted in
+// the managed resource itself is tracked in #223.
+func (l loggableObject) MarshalLog() any {
+	spec, specRedacted := redactSecretManifest(l.obj.Spec.ForProvider.Manifest.Raw)
+	status, statusRedacted := redactSecretManifest(l.obj.Status.AtProvider.Manifest.Raw)
+	if !specRedacted && !statusRedacted {
+		return l.obj
+	}
+	logged := l.obj.DeepCopy()
+	logged.Spec.ForProvider.Manifest.Raw = spec
+	logged.Status.AtProvider.Manifest.Raw = status
+	return logged
+}
+
+// isSecret returns whether the given object is a v1 Secret.
+func isSecret(u *unstructured.Unstructured) bool {
+	return u.GetAPIVersion() == "v1" && u.GetKind() == "Secret"
+}
+
+// redactField replaces the contents of the named top-level field with a
+// redaction marker.
+func redactField(u *unstructured.Unstructured, field string) error {
+	data := map[string][]byte{"redacted": []byte(nil)}
+	return fieldpath.Pave(u.Object).SetValue(field, data)
+}
+
+// redactSecretManifest replaces the data and stringData contents of a raw
+// v1 Secret manifest with a redaction marker. Non-Secret manifests and
+// unparseable payloads are returned unchanged.
+func redactSecretManifest(raw []byte) ([]byte, bool) {
+	u := &unstructured.Unstructured{}
+	if err := json.Unmarshal(raw, u); err != nil || !isSecret(u) {
+		return raw, false
+	}
+	redacted := false
+	for _, field := range []string{"data", "stringData"} {
+		if _, ok := u.Object[field]; ok {
+			if err := redactField(u, field); err != nil {
+				// prefer dropping the manifest from the log line over
+				// leaking secret data
+				return nil, true
+			}
+			redacted = true
+		}
+	}
+	if !redacted {
+		return raw, false
+	}
+	out, err := u.MarshalJSON()
+	if err != nil {
+		// should not happen for an object that was just unmarshalled; prefer
+		// dropping the manifest from the log line over leaking secret data
+		return nil, true
+	}
+	return out, true
+}
+
 func (c *external) setAtProvider(obj *v1alpha2.Object, observed *unstructured.Unstructured) error {
 	var err error
 
@@ -525,12 +596,9 @@ func (c *external) setAtProvider(obj *v1alpha2.Object, observed *unstructured.Un
 	if c.removeManagedFields {
 		sObserved.SetManagedFields(nil)
 	}
-	if c.sanitizeSecrets {
-		if observed.GetKind() == "Secret" && observed.GetAPIVersion() == "v1" {
-			data := map[string][]byte{"redacted": []byte(nil)}
-			if err = fieldpath.Pave(sObserved.Object).SetValue("data", data); err != nil {
-				return errors.Wrap(err, errSanitizeSecretData)
-			}
+	if c.sanitizeSecrets && isSecret(sObserved) {
+		if err = redactField(sObserved, "data"); err != nil {
+			return errors.Wrap(err, errSanitizeSecretData)
 		}
 	}
 

--- a/internal/controller/cluster/object/object_test.go
+++ b/internal/controller/cluster/object/object_test.go
@@ -1984,3 +1984,95 @@ func TestSetAtProviderRemovesManagedFields(t *testing.T) {
 		})
 	}
 }
+
+func TestLoggableRedactsSecretData(t *testing.T) {
+	secretManifest := []byte(`{"apiVersion":"v1","kind":"Secret","metadata":{"name":"creds"},"data":{"password":"c2VjcmV0"},"stringData":{"user":"admin"}}`)
+	redactedManifest := []byte(`{"apiVersion":"v1","kind":"Secret","metadata":{"name":"creds"},"data":{"redacted":null},"stringData":{"redacted":null}}`)
+	secretWithoutData := []byte(`{"apiVersion":"v1","kind":"Secret","metadata":{"name":"creds"}}`)
+	configMapManifest := []byte(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm"},"data":{"key":"value"}}`)
+	invalidManifest := []byte(`{not json`)
+
+	normalize := func(raw []byte) interface{} {
+		var v interface{}
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return string(raw)
+		}
+		return v
+	}
+
+	type args struct {
+		obj *v1alpha2.Object
+	}
+	type want struct {
+		spec   []byte
+		status []byte
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"SecretDataAndStringDataRedacted": {
+			args: args{
+				obj: kubernetesObject(func(obj *v1alpha2.Object) {
+					obj.Spec.ForProvider.Manifest.Raw = secretManifest
+					obj.Status.AtProvider.Manifest.Raw = secretManifest
+				}),
+			},
+			want: want{
+				spec:   redactedManifest,
+				status: redactedManifest,
+			},
+		},
+		"SecretWithoutDataUntouched": {
+			args: args{
+				obj: kubernetesObject(func(obj *v1alpha2.Object) {
+					obj.Spec.ForProvider.Manifest.Raw = secretWithoutData
+				}),
+			},
+			want: want{
+				spec: secretWithoutData,
+			},
+		},
+		"NonSecretManifestUntouched": {
+			args: args{
+				obj: kubernetesObject(func(obj *v1alpha2.Object) {
+					obj.Spec.ForProvider.Manifest.Raw = configMapManifest
+				}),
+			},
+			want: want{
+				spec: configMapManifest,
+			},
+		},
+		"UnparseableManifestUntouched": {
+			args: args{
+				obj: kubernetesObject(func(obj *v1alpha2.Object) {
+					obj.Spec.ForProvider.Manifest.Raw = invalidManifest
+				}),
+			},
+			want: want{
+				spec: invalidManifest,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			specBefore := string(tc.args.obj.Spec.ForProvider.Manifest.Raw)
+
+			got, ok := loggable(tc.args.obj).MarshalLog().(*v1alpha2.Object)
+			if !ok {
+				t.Fatalf("MarshalLog() did not return an Object")
+			}
+
+			if diff := cmp.Diff(normalize(tc.want.spec), normalize(got.Spec.ForProvider.Manifest.Raw)); diff != "" {
+				t.Errorf("spec manifest: -want +got\n%s", diff)
+			}
+			if diff := cmp.Diff(normalize(tc.want.status), normalize(got.Status.AtProvider.Manifest.Raw)); diff != "" {
+				t.Errorf("status manifest: -want +got\n%s", diff)
+			}
+			if diff := cmp.Diff(specBefore, string(tc.args.obj.Spec.ForProvider.Manifest.Raw)); diff != "" {
+				t.Errorf("original Object was mutated: -want +got\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/controller/namespaced/object/object.go
+++ b/internal/controller/namespaced/object/object.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/google/cel-go/cel"
 	celtypes "github.com/google/cel-go/common/types"
 	"github.com/pkg/errors"
@@ -375,7 +376,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.New(errNotKubernetesObject)
 	}
 
-	c.logger.Debug("Observing", "resource", obj)
+	c.logger.Debug("Observing", "resource", loggable(obj))
 
 	if !meta.WasDeleted(obj) {
 		// If the object is not being deleted, we need to resolve references
@@ -436,7 +437,7 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalCreation{}, errors.New(errNotKubernetesObject)
 	}
 
-	c.logger.Debug("Creating", "resource", obj)
+	c.logger.Debug("Creating", "resource", loggable(obj))
 
 	res, err := parseManifest(obj)
 	if err != nil {
@@ -456,7 +457,7 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalUpdate{}, errors.New(errNotKubernetesObject)
 	}
 
-	c.logger.Debug("Updating", "resource", obj)
+	c.logger.Debug("Updating", "resource", loggable(obj))
 
 	res, err := parseManifest(obj)
 	if err != nil {
@@ -482,7 +483,7 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 		PropagationPolicy: &propagationPolicy,
 	}
 
-	c.logger.Debug("Deleting", "resource", obj, "propagationPolicy", obj.Spec.ForProvider.DeletionPropagationPolicy)
+	c.logger.Debug("Deleting", "resource", loggable(obj), "propagationPolicy", obj.Spec.ForProvider.DeletionPropagationPolicy)
 
 	res, err := parseManifest(obj)
 	if err != nil {
@@ -518,6 +519,76 @@ func parseManifest(obj *v1alpha1.Object) (*unstructured.Unstructured, error) {
 	return r, nil
 }
 
+// loggable wraps an Object for debug logging so that Secret data is redacted
+// lazily, only when the log line is actually emitted.
+func loggable(obj *v1alpha1.Object) logr.Marshaler {
+	return loggableObject{obj: obj}
+}
+
+type loggableObject struct {
+	obj *v1alpha1.Object
+}
+
+// MarshalLog implements logr.Marshaler. It returns a copy of the Object with
+// the data and stringData of a wrapped v1 Secret manifest redacted in both
+// the desired manifest and the observed state, so that secret values do not
+// end up in provider logs. The deeper handling of secret values persisted in
+// the managed resource itself is tracked in #223.
+func (l loggableObject) MarshalLog() any {
+	spec, specRedacted := redactSecretManifest(l.obj.Spec.ForProvider.Manifest.Raw)
+	status, statusRedacted := redactSecretManifest(l.obj.Status.AtProvider.Manifest.Raw)
+	if !specRedacted && !statusRedacted {
+		return l.obj
+	}
+	logged := l.obj.DeepCopy()
+	logged.Spec.ForProvider.Manifest.Raw = spec
+	logged.Status.AtProvider.Manifest.Raw = status
+	return logged
+}
+
+// isSecret returns whether the given object is a v1 Secret.
+func isSecret(u *unstructured.Unstructured) bool {
+	return u.GetAPIVersion() == "v1" && u.GetKind() == "Secret"
+}
+
+// redactField replaces the contents of the named top-level field with a
+// redaction marker.
+func redactField(u *unstructured.Unstructured, field string) error {
+	data := map[string][]byte{"redacted": []byte(nil)}
+	return fieldpath.Pave(u.Object).SetValue(field, data)
+}
+
+// redactSecretManifest replaces the data and stringData contents of a raw
+// v1 Secret manifest with a redaction marker. Non-Secret manifests and
+// unparseable payloads are returned unchanged.
+func redactSecretManifest(raw []byte) ([]byte, bool) {
+	u := &unstructured.Unstructured{}
+	if err := json.Unmarshal(raw, u); err != nil || !isSecret(u) {
+		return raw, false
+	}
+	redacted := false
+	for _, field := range []string{"data", "stringData"} {
+		if _, ok := u.Object[field]; ok {
+			if err := redactField(u, field); err != nil {
+				// prefer dropping the manifest from the log line over
+				// leaking secret data
+				return nil, true
+			}
+			redacted = true
+		}
+	}
+	if !redacted {
+		return raw, false
+	}
+	out, err := u.MarshalJSON()
+	if err != nil {
+		// should not happen for an object that was just unmarshalled; prefer
+		// dropping the manifest from the log line over leaking secret data
+		return nil, true
+	}
+	return out, true
+}
+
 func (c *external) setAtProvider(obj *v1alpha1.Object, observed *unstructured.Unstructured) error {
 	var err error
 
@@ -526,12 +597,9 @@ func (c *external) setAtProvider(obj *v1alpha1.Object, observed *unstructured.Un
 	if c.removeManagedFields {
 		sObserved.SetManagedFields(nil)
 	}
-	if c.sanitizeSecrets {
-		if observed.GetKind() == "Secret" && observed.GetAPIVersion() == "v1" {
-			data := map[string][]byte{"redacted": []byte(nil)}
-			if err = fieldpath.Pave(sObserved.Object).SetValue("data", data); err != nil {
-				return errors.Wrap(err, errSanitizeSecretData)
-			}
+	if c.sanitizeSecrets && isSecret(sObserved) {
+		if err = redactField(sObserved, "data"); err != nil {
+			return errors.Wrap(err, errSanitizeSecretData)
 		}
 	}
 

--- a/internal/controller/namespaced/object/object_test.go
+++ b/internal/controller/namespaced/object/object_test.go
@@ -1985,3 +1985,95 @@ func TestSetAtProviderRemovesManagedFields(t *testing.T) {
 		})
 	}
 }
+
+func TestLoggableRedactsSecretData(t *testing.T) {
+	secretManifest := []byte(`{"apiVersion":"v1","kind":"Secret","metadata":{"name":"creds"},"data":{"password":"c2VjcmV0"},"stringData":{"user":"admin"}}`)
+	redactedManifest := []byte(`{"apiVersion":"v1","kind":"Secret","metadata":{"name":"creds"},"data":{"redacted":null},"stringData":{"redacted":null}}`)
+	secretWithoutData := []byte(`{"apiVersion":"v1","kind":"Secret","metadata":{"name":"creds"}}`)
+	configMapManifest := []byte(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm"},"data":{"key":"value"}}`)
+	invalidManifest := []byte(`{not json`)
+
+	normalize := func(raw []byte) interface{} {
+		var v interface{}
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return string(raw)
+		}
+		return v
+	}
+
+	type args struct {
+		obj *objv1alpha1.Object
+	}
+	type want struct {
+		spec   []byte
+		status []byte
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"SecretDataAndStringDataRedacted": {
+			args: args{
+				obj: kubernetesObject(func(obj *objv1alpha1.Object) {
+					obj.Spec.ForProvider.Manifest.Raw = secretManifest
+					obj.Status.AtProvider.Manifest.Raw = secretManifest
+				}),
+			},
+			want: want{
+				spec:   redactedManifest,
+				status: redactedManifest,
+			},
+		},
+		"SecretWithoutDataUntouched": {
+			args: args{
+				obj: kubernetesObject(func(obj *objv1alpha1.Object) {
+					obj.Spec.ForProvider.Manifest.Raw = secretWithoutData
+				}),
+			},
+			want: want{
+				spec: secretWithoutData,
+			},
+		},
+		"NonSecretManifestUntouched": {
+			args: args{
+				obj: kubernetesObject(func(obj *objv1alpha1.Object) {
+					obj.Spec.ForProvider.Manifest.Raw = configMapManifest
+				}),
+			},
+			want: want{
+				spec: configMapManifest,
+			},
+		},
+		"UnparseableManifestUntouched": {
+			args: args{
+				obj: kubernetesObject(func(obj *objv1alpha1.Object) {
+					obj.Spec.ForProvider.Manifest.Raw = invalidManifest
+				}),
+			},
+			want: want{
+				spec: invalidManifest,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			specBefore := string(tc.args.obj.Spec.ForProvider.Manifest.Raw)
+
+			got, ok := loggable(tc.args.obj).MarshalLog().(*objv1alpha1.Object)
+			if !ok {
+				t.Fatalf("MarshalLog() did not return an Object")
+			}
+
+			if diff := cmp.Diff(normalize(tc.want.spec), normalize(got.Spec.ForProvider.Manifest.Raw)); diff != "" {
+				t.Errorf("spec manifest: -want +got\n%s", diff)
+			}
+			if diff := cmp.Diff(normalize(tc.want.status), normalize(got.Status.AtProvider.Manifest.Raw)); diff != "" {
+				t.Errorf("status manifest: -want +got\n%s", diff)
+			}
+			if diff := cmp.Diff(specBefore, string(tc.args.obj.Spec.ForProvider.Manifest.Raw)); diff != "" {
+				t.Errorf("original Object was mutated: -want +got\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

With `--debug`, the `Observing`/`Creating`/`Updating`/`Deleting` log sites dump the full `Object`, including the `data`/`stringData` of a wrapped `v1` `Secret` manifest in `spec.forProvider.manifest` and `status.atProvider.manifest` — so secret values end up in provider logs.

This wraps the logged `Object` in a `logr.Marshaler` that replaces `data` and `stringData` of Secret manifests with a redaction marker. The redaction runs lazily, only when the log line is actually emitted (i.e. only in debug mode), so there is no cost on the hot path, and non-Secret manifests are logged unchanged. Both the cluster-scoped and namespaced controllers are covered.

The deeper question of secret values persisted in the managed resource itself remains tracked in #223.

Fixes #250

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

New table-driven `TestLoggableRedactsSecretData` in both controllers: Secret `data`+`stringData` redacted in spec and status, Secret without data untouched, non-Secret manifest untouched, unparseable manifest untouched, and the original `Object` is never mutated. Full package suites, `golangci-lint`, `go build`/`go vet` green locally.

[contribution process]: https://git.io/fj2m9
