### PR TITLE
docs: document write-only field limitation in Object manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,37 @@ spec:
   package: xpkg.crossplane.io/crossplane-contrib/provider-kubernetes:v1.0.0
 ```
 
+## Known limitations
+
+### Write-only fields cannot be reconciled
+
+Some Kubernetes fields are "write-only": the API server accepts them but
+transforms or drops them on write, so they never appear when the resource is
+read back. The canonical example is `Secret.stringData`, which the API server
+merges into `data` without ever storing `stringData` itself.
+
+The provider cannot correctly reconcile such fields in an `Object` manifest
+(see the analysis in
+[#420](https://github.com/crossplane-contrib/provider-kubernetes/issues/420)):
+
+- With server-side apply (the default since v1.2.0), drift detection compares
+  the fields owned by the provider's field manager on the observed resource
+  against the result of a dry-run apply of the manifest. A write-only field
+  appears in neither, so changing e.g. `stringData` in the manifest after
+  creation produces no diff and is never applied to the cluster. The provider
+  has no way of knowing that `data` is the server-side transformation of
+  `stringData`.
+- If the provider's field manager owns *only* fields that are absent from the
+  observed resource — a `Secret` whose manifest sets only `stringData`
+  ([#420](https://github.com/crossplane-contrib/provider-kubernetes/issues/420)),
+  or one created with an empty `data`
+  ([#418](https://github.com/crossplane-contrib/provider-kubernetes/issues/418)) —
+  the managed-fields extraction fails with `ExtractInto ... expected map, got
+  <nil>` and the `Object` gets stuck with `Synced: False` in `ReconcileError`.
+
+Prefer round-trippable fields in `Object` manifests: for `Secret`s, set
+base64-encoded values in `data` instead of using `stringData`.
+
 ## Developing locally
 
 See the header of [`go.mod`](./go.mod) for the minimum supported version of Go.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,37 @@ informers and the server-side apply discovery client. Load on the target
 cluster is bounded by `--max-reconcile-rate` on the provider side and by API
 Priority and Fairness on the API server.
 
+## Known limitations
+
+### Write-only fields cannot be reconciled
+
+Some Kubernetes fields are "write-only": the API server accepts them but
+transforms or drops them on write, so they never appear when the resource is
+read back. The canonical example is `Secret.stringData`, which the API server
+merges into `data` without ever storing `stringData` itself.
+
+The provider cannot correctly reconcile such fields in an `Object` manifest
+(see the analysis in
+[#420](https://github.com/crossplane-contrib/provider-kubernetes/issues/420)):
+
+- With server-side apply (the default since v1.2.0), drift detection compares
+  the fields owned by the provider's field manager on the observed resource
+  against the result of a dry-run apply of the manifest. A write-only field
+  appears in neither, so changing e.g. `stringData` in the manifest after
+  creation produces no diff and is never applied to the cluster. The provider
+  has no way of knowing that `data` is the server-side transformation of
+  `stringData`.
+- If the provider's field manager owns *only* fields that are absent from the
+  observed resource — a `Secret` whose manifest sets only `stringData`
+  ([#420](https://github.com/crossplane-contrib/provider-kubernetes/issues/420)),
+  or one created with an empty `data`
+  ([#418](https://github.com/crossplane-contrib/provider-kubernetes/issues/418)) —
+  the managed-fields extraction fails with `ExtractInto ... expected map, got
+  <nil>` and the `Object` gets stuck with `Synced: False` in `ReconcileError`.
+
+Prefer round-trippable fields in `Object` manifests: for `Secret`s, set
+base64-encoded values in `data` instead of using `stringData`.
+
 ## Developing locally
 
 See the header of [`go.mod`](./go.mod) for the minimum supported version of Go.


### PR DESCRIPTION
### Description of your changes

Adds a "Known limitations" README section documenting that write-only fields (canonically `Secret.stringData`) cannot be correctly reconciled in `Object` manifests, per the analysis in #420:

- under server-side apply, a write-only field appears in neither the observed extraction nor the dry-run desired state, so post-creation changes to it produce no diff and are silently not applied;
- when the provider's field manager owns only such fields, the managed-fields extraction fails with `ExtractInto ... expected map, got <nil>` and the `Object` is stuck in `ReconcileError` (#420, #418).

Recommends round-trippable fields instead (base64 `data` for Secrets). This documents the limitation as suggested in the #420 thread; the issues themselves stay open for the underlying extractor fix.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Documentation-only change; rendered locally.

[contribution process]: https://git.io/fj2m9
