### PR TITLE
docs: add Kubernetes compatibility section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,27 @@ spec:
   package: xpkg.crossplane.io/crossplane-contrib/provider-kubernetes:v1.0.0
 ```
 
+## Kubernetes compatibility
+
+The provider interacts with two kinds of clusters: the control plane it runs
+on (where Crossplane and the `Object` managed resources live) and the target
+clusters referenced by its `ProviderConfig`s (where the wrapped objects are
+applied), which may be the control plane itself.
+
+Each release is built against the [`k8s.io/client-go`](https://github.com/kubernetes/client-go)
+version pinned in that release's [`go.mod`](./go.mod) — for example `v0.35.x`
+corresponds to Kubernetes 1.35. Per the client-go
+[compatibility matrix](https://github.com/kubernetes/client-go#compatibility-matrix)
+and the Kubernetes [version skew policy](https://kubernetes.io/releases/version-skew-policy/),
+that client version is supported against the same Kubernetes minor version,
+one minor older, and one minor newer.
+
+In practice the provider is not very sensitive to the exact server version:
+it manages arbitrary objects generically, using unstructured types,
+server-side apply, and each target cluster's own discovery and OpenAPI data.
+Clusters outside the official skew therefore usually work, but only the
+client-go range above is tested and supported.
+
 ## Developing locally
 
 See the header of [`go.mod`](./go.mod) for the minimum supported version of Go.


### PR DESCRIPTION
### Description of your changes

Adds a "Kubernetes compatibility" README section: the supported Kubernetes range follows the `k8s.io/client-go` version pinned in each release's `go.mod`, per the client-go compatibility matrix and the Kubernetes version-skew policy, with a note on why the provider is tolerant of clusters outside that range in practice (unstructured types, server-side apply, per-cluster discovery/OpenAPI data).

Fixes #279

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Documentation-only change; rendered locally.

[contribution process]: https://git.io/fj2m9
