### PR TITLE
fix: cache per-ProviderConfig clients to avoid discovery per reconcile

### DIFF
--- a/pkg/kube/client/cache.go
+++ b/pkg/kube/client/cache.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 The Crossplane Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"container/list"
+	"sync"
+
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// defaultClientCacheSize bounds how many credential-set -> client entries are
+// kept per builder. Each entry holds a client with its own RESTMapper and HTTP
+// transport; the least recently used entry is evicted beyond the bound.
+const defaultClientCacheSize = 64
+
+type cachedClient struct {
+	kube client.Client
+	rc   *rest.Config
+}
+
+// clientCache is an LRU cache of built Kubernetes clients keyed by a digest of
+// the credential material that produced them. Building a client is expensive:
+// its RESTMapper primes itself via aggregated discovery, a multi-megabyte
+// download and decode on CRD-heavy clusters, so clients must be reused across
+// reconciles for as long as their credentials remain unchanged.
+type clientCache struct {
+	mu      sync.Mutex
+	size    int
+	entries map[string]*list.Element
+	order   *list.List // front = most recently used
+}
+
+type clientCacheEntry struct {
+	key string
+	val cachedClient
+}
+
+func newClientCache(size int) *clientCache {
+	return &clientCache{
+		size:    size,
+		entries: make(map[string]*list.Element),
+		order:   list.New(),
+	}
+}
+
+func (c *clientCache) get(key string) (cachedClient, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	el, ok := c.entries[key]
+	if !ok {
+		return cachedClient{}, false
+	}
+	c.order.MoveToFront(el)
+	return el.Value.(*clientCacheEntry).val, true
+}
+
+func (c *clientCache) put(key string, val cachedClient) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if el, ok := c.entries[key]; ok {
+		c.order.MoveToFront(el)
+		el.Value.(*clientCacheEntry).val = val
+		return
+	}
+	c.entries[key] = c.order.PushFront(&clientCacheEntry{key: key, val: val})
+	if c.order.Len() > c.size {
+		oldest := c.order.Back()
+		c.order.Remove(oldest)
+		delete(c.entries, oldest.Value.(*clientCacheEntry).key)
+	}
+}

--- a/pkg/kube/client/cache_test.go
+++ b/pkg/kube/client/cache_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2026 The Crossplane Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
+
+	kconfig "github.com/crossplane-contrib/provider-kubernetes/pkg/kube/config"
+)
+
+func kubeconfigFor(server string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    server: %s
+contexts:
+- name: ctx
+  context:
+    cluster: c
+    user: u
+current-context: ctx
+users:
+- name: u
+  user:
+    token: t
+`, server)
+}
+
+func secretLocalClient(kubeconfigs map[string]string) client.Client {
+	return &test.MockClient{
+		MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+			s, ok := obj.(*corev1.Secret)
+			if !ok {
+				return fmt.Errorf("unexpected object type %T", obj)
+			}
+			kc, ok := kubeconfigs[key.Name]
+			if !ok {
+				return fmt.Errorf("no kubeconfig for secret %q", key.Name)
+			}
+			s.Data = map[string][]byte{"kubeconfig": []byte(kc)}
+			return nil
+		},
+	}
+}
+
+func pcSpec(secretName string) kconfig.ProviderConfigSpec {
+	return kconfig.ProviderConfigSpec{
+		Credentials: kconfig.ProviderCredentials{
+			Source: xpv2.CredentialsSourceSecret,
+			CommonCredentialSelectors: xpv2.CommonCredentialSelectors{
+				SecretRef: &xpv2.SecretKeySelector{
+					SecretReference: xpv2.SecretReference{
+						Name:      secretName,
+						Namespace: types.NamespacedName{Namespace: "crossplane-system"}.Namespace,
+					},
+					Key: "kubeconfig",
+				},
+			},
+		},
+	}
+}
+
+func TestKubeForProviderConfigCaching(t *testing.T) {
+	type args struct {
+		kubeconfigs map[string]string
+		firstPC     kconfig.ProviderConfigSpec
+		secondPC    kconfig.ProviderConfigSpec
+	}
+	type want struct {
+		sameClient bool
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"SameCredentialsReuseClient": {
+			args: args{
+				kubeconfigs: map[string]string{
+					"creds": kubeconfigFor("https://example.org:6443"),
+				},
+				firstPC:  pcSpec("creds"),
+				secondPC: pcSpec("creds"),
+			},
+			want: want{sameClient: true},
+		},
+		"DifferentCredentialsBuildNewClient": {
+			args: args{
+				kubeconfigs: map[string]string{
+					"creds-a": kubeconfigFor("https://a.example.org:6443"),
+					"creds-b": kubeconfigFor("https://b.example.org:6443"),
+				},
+				firstPC:  pcSpec("creds-a"),
+				secondPC: pcSpec("creds-b"),
+			},
+			want: want{sameClient: false},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			b := NewIdentityAwareBuilder(secretLocalClient(tc.args.kubeconfigs))
+
+			first, _, err := b.KubeForProviderConfig(context.Background(), tc.args.firstPC)
+			if err != nil {
+				t.Fatalf("first KubeForProviderConfig(...): unexpected error: %v", err)
+			}
+			second, _, err := b.KubeForProviderConfig(context.Background(), tc.args.secondPC)
+			if err != nil {
+				t.Fatalf("second KubeForProviderConfig(...): unexpected error: %v", err)
+			}
+
+			if got := first == second; got != tc.want.sameClient {
+				t.Errorf("KubeForProviderConfig(...): same client = %v, want %v", got, tc.want.sameClient)
+			}
+		})
+	}
+}
+
+func TestClientCacheEviction(t *testing.T) {
+	c := newClientCache(2)
+	c.put("a", cachedClient{})
+	c.put("b", cachedClient{})
+	if _, ok := c.get("a"); !ok { // refresh "a" so "b" is least recently used
+		t.Fatal("expected key a to be cached")
+	}
+	c.put("c", cachedClient{})
+
+	if _, ok := c.get("b"); ok {
+		t.Error("expected least recently used key b to be evicted")
+	}
+	for _, k := range []string{"a", "c"} {
+		if _, ok := c.get(k); !ok {
+			t.Errorf("expected key %s to remain cached", k)
+		}
+	}
+}

--- a/pkg/kube/client/client.go
+++ b/pkg/kube/client/client.go
@@ -15,11 +15,15 @@ package client
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"hash"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sync/singleflight"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -72,6 +76,8 @@ type IdentityAwareBuilder struct {
 	local       client.Client
 	store       *token.ReuseSourceStore
 	nebiusStore *nebius.SDKStore
+	clients     *clientCache
+	building    singleflight.Group
 }
 
 // NewIdentityAwareBuilder returns a new IdentityAwareBuilder.
@@ -80,25 +86,62 @@ func NewIdentityAwareBuilder(local client.Client) *IdentityAwareBuilder {
 		local:       local,
 		store:       token.NewReuseSourceStore(),
 		nebiusStore: nebius.NewSDKStore(),
+		clients:     newClientCache(defaultClientCacheSize),
 	}
 }
 
 // KubeForProviderConfig returns the kube client and *rest.config for the given
-// provider config.
+// provider config. Clients are cached by a digest of the credential material
+// that produced them: constructing a client is expensive because its
+// RESTMapper primes itself via aggregated discovery (the whole API surface,
+// multi-megabyte on CRD-heavy clusters), and this method is called on every
+// reconcile. A credential change yields a new digest and thus a fresh client;
+// token refresh happens inside the cached transports and needs no rebuild.
 func (b *IdentityAwareBuilder) KubeForProviderConfig(ctx context.Context, pc kconfig.ProviderConfigSpec) (client.Client, *rest.Config, error) {
-	rc, err := b.restForProviderConfig(ctx, pc)
+	digest := sha256.New()
+	rc, err := b.restForProviderConfig(ctx, pc, digest)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "cannot get REST config for provider")
 	}
-	k, err := client.New(rc, client.Options{})
+	key := hex.EncodeToString(digest.Sum(nil))
+	if cached, ok := b.clients.get(key); ok {
+		return cached.kube, cached.rc, nil
+	}
+	// singleflight collapses the thundering herd of concurrent reconciles
+	// racing to build the same client on a cold cache (e.g. provider start).
+	v, err, _ := b.building.Do(key, func() (any, error) {
+		if cached, ok := b.clients.get(key); ok {
+			return cached, nil
+		}
+		k, err := client.New(rc, client.Options{})
+		if err != nil {
+			return nil, err
+		}
+		cached := cachedClient{kube: k, rc: rc}
+		b.clients.put(key, cached)
+		return cached, nil
+	})
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "cannot create Kubernetes client for provider")
 	}
-	return k, rc, nil
+	cached := v.(cachedClient)
+	return cached.kube, cached.rc, nil
 }
 
-// restForProviderConfig returns the *rest.config for the given provider config.
-func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kconfig.ProviderConfigSpec) (*rest.Config, error) { // nolint:gocyclo
+// digestWrite feeds a piece of client-defining material into the cache-key
+// digest, NUL-delimited so adjacent fields cannot alias.
+func digestWrite(d hash.Hash, material ...[]byte) {
+	for _, m := range material {
+		d.Write(m)
+		d.Write([]byte{0})
+	}
+}
+
+// restForProviderConfig returns the *rest.config for the given provider
+// config. Every input that shapes the resulting config (credential source,
+// extracted credential bytes, identity type and credentials) is also written
+// to digest, which callers use as the client cache key.
+func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kconfig.ProviderConfigSpec, digest hash.Hash) (*rest.Config, error) { // nolint:gocyclo
 	var (
 		rc  *rest.Config
 		err error
@@ -111,11 +154,13 @@ func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kco
 		if err != nil {
 			return nil, errors.Wrap(err, errCreateRestConfig)
 		}
+		digestWrite(digest, []byte(cd.Source))
 	default:
 		kc, err := resource.CommonCredentialExtractor(ctx, cd.Source, b.local, cd.CommonCredentialSelectors)
 		if err != nil {
 			return nil, errors.Wrap(err, errGetCreds)
 		}
+		digestWrite(digest, []byte(cd.Source), kc)
 
 		ac, err = clientcmd.Load(kc)
 		if err != nil {
@@ -128,6 +173,7 @@ func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kco
 	}
 
 	if id := pc.Identity; id != nil {
+		digestWrite(digest, []byte(id.Type), []byte(id.Source))
 		switch id.Type {
 		case kconfig.IdentityTypeGoogleApplicationCredentials:
 			switch id.Source { //nolint:exhaustive
@@ -140,6 +186,7 @@ func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kco
 				if err != nil {
 					return nil, errors.Wrap(err, errExtractGoogleCredentials)
 				}
+				digestWrite(digest, creds)
 
 				if err := gke.WrapRESTConfig(ctx, rc, creds, gke.DefaultScopes...); err != nil {
 					return nil, errors.Wrap(err, errInjectGoogleCredentials)
@@ -155,6 +202,7 @@ func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kco
 				if err != nil {
 					return nil, errors.Wrap(err, errExtractAzureCredentials)
 				}
+				digestWrite(digest, creds)
 
 				if err := azure.WrapRESTConfig(ctx, rc, creds, id.Type); err != nil {
 					return nil, errors.Wrap(err, errInjectAzureCredentials)
@@ -170,6 +218,7 @@ func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kco
 				if err != nil {
 					return nil, errors.Wrap(err, errExtractUpboundCredentials)
 				}
+				digestWrite(digest, staticToken)
 
 				// We trim the token to remove any leading/trailing whitespace
 				// which may have been added especially when stringData field
@@ -190,6 +239,7 @@ func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kco
 						clusterName = ctxConfig.Cluster
 					}
 				}
+				digestWrite(digest, []byte(clusterName))
 				// AWS Web Identity credentials use the default AWS credentials chain
 				// which includes IRSA (IAM Roles for Service Accounts) via environment variables:
 				// AWS_ROLE_ARN, AWS_WEB_IDENTITY_TOKEN_FILE, AWS_REGION
@@ -210,6 +260,7 @@ func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kco
 				if err != nil {
 					return nil, errors.Wrap(err, errExtractNebiusCredentials)
 				}
+				digestWrite(digest, creds)
 				if err := nebius.WrapRESTConfig(ctx, rc, creds, b.nebiusStore); err != nil {
 					return nil, errors.Wrap(err, errInjectNebiusCredentials)
 				}


### PR DESCRIPTION
### Description of your changes

Fixes an unreleased ~3x memory / ~5x CPU regression on `main` (not in any cut release — `v1.2.1` is unaffected) by caching per-ProviderConfig clients in `IdentityAwareBuilder` instead of building a fresh client on every reconcile. Full root cause analysis below.

#### What happens

1. Every reconcile calls `connector.Connect`, which builds a **fresh** controller-runtime client for the ProviderConfig's target cluster: [`pkg/kube/client/client.go:93`](https://github.com/crossplane-contrib/provider-kubernetes/blob/350ef9acf911654b9d54d62a4ca4d7f0d0b13341/pkg/kube/client/client.go#L88-L98) (`client.New(rc, client.Options{})`).
2. A fresh client owns a fresh `DynamicRESTMapper`. Since the controller-runtime bump in [`b4bd483`](https://github.com/crossplane-contrib/provider-kubernetes/commit/b4bd48391ce5c53444563363cfe7f3b2febf89ae) (`v0.19.0` → `v0.23.1`, part of the crossplane-runtime v2.3.3 update), a fresh mapper primes itself with **aggregated discovery**: `GET /api` + `GET /apis`, returning every group, version, and resource in the cluster in one document.
3. On CRD-heavy clusters that document is multi-megabyte, and it is fetched and decoded **twice per reconcile**. At `--max-reconcile-rate=100` up to 100 decodes are in flight concurrently — live heap genuinely reaches ~2 GiB, the GC then frees it, and the working set decays slowly, which reads as a high "steady state" in coarse memory sampling.

**Confirmed (code, controller-runtime `v0.19.0`):** the mapper fetched lazily and per-group — `fetchGroupVersionResourcesLocked(groupName, versions...)` (`pkg/client/apiutil/restmapper.go:275`) retrieves only the group/version being mapped. Mapping `v1/Secret` cost one small `/api/v1` fetch.

**Confirmed (code, controller-runtime `v0.23.1`):** the mapper holds a `discovery.AggregatedDiscoveryInterface` (`pkg/client/apiutil/restmapper.go:58`) and on lookup *always* runs a full aggregated fetch first (comment at `restmapper.go:174-187`). Lazy per-group fetching no longer happens against servers that support aggregated discovery (Kubernetes ≥ v1.27).

#### Root cause (confirmed at source + measured on-cluster)

Per-reconcile client construction (pre-existing, cheap under controller-runtime `v0.19`) **multiplied by** the new always-aggregated mapper priming (expensive on CRD-heavy clusters) — neither alone regresses; `b4bd483` made the combination pathological.

Hypotheses eliminated on the way:

**Falsified:** per-`Object` duplication of watch caches — the informer diff between `v1.2.1` and `main` is exactly #425 (`Unstructured` → `PartialObjectMetadata`, managed-fields strip); the per-`(providerConfig, GVK)` keying is unchanged.

**Falsified:** reconcile hot loop — at settle with 300 Objects, `controller_runtime_reconcile_total` and `rest_client_requests_total` moved by exactly 0 over 60 s while the pod held ~1.6 GiB.

**Falsified:** fat resident caches — `go_memstats_heap_inuse_bytes` under load is ~335 MiB on **both** builds (335 vs 337 MiB); resident cache content is equivalent.

#### Measurement evidence

**Tested (kind v1.36.1 arm64, 2026-08-07):** 1572 CRDs + 3000 baggage `Secret`s in the cluster, 300 `Object`s (`spec.watch: true`, managed `Secret` + `patchesFrom` source `Secret`), 5 update rounds, kubelet `/stats/summary` sampling (`workingSetBytes`, MiB):

```
v1.2.1:
phase             samples     avgMiB     maxMiB    maxCPUm
baseline                9      297.2      445.8       62.4
cache-settle           12      663.8      663.8        3.6
steady                 12      611.3      611.7      187.9
update-round-4          4      598.3      601.7      296.7

main (350ef9a):
phase             samples     avgMiB     maxMiB    maxCPUm
baseline                9      369.4      474.9      141.5
cache-settle           12     2125.4     2125.4        3.8
steady                 12     1699.9     1699.9      980.0
update-round-5          4     1654.5     1699.9      980.0
```

**Tested (same cluster, same 300 Objects):** `apiserver_request_total` delta over one 300-secret patch round + 45 s, summed by verb/resource — the only asymmetry between builds is aggregated discovery:

```
main:                              v1.2.1:
1522 GET /secrets                  1732 GET /secrets
 921 GET /.openapi/v3             1026 GET /.openapi/v3
 614 GET /.apis                      3 GET /.apis
 614 GET /.api                       3 GET /.api
 600 APPLY /secrets                600 APPLY /secrets
 300 PATCH /secrets                300 PATCH /secrets
```

Provider heap during that round (`go_memstats`, sampled every 5 s):

```
main:   heap_sys min 2031 max 2276, heap_inuse max 1964
v1.2.1: heap_sys min  538 max  586, heap_inuse max  445
```

Idle `main` pod after load (working set decayed, spike retained by the runtime):

```
go_memstats_heap_sys_bytes      2.153644032e+09   (~2.15 GiB)
go_memstats_heap_inuse_bytes    2.98778624e+08    (~285 MiB)
go_memstats_heap_released_bytes 1.540448256e+09   (~1.54 GiB already madvised)
go_goroutines                   725
```

The ~1000 `GET /.openapi/v3` per round (~3 per reconcile, SSA extractor etag checks) appear **in both builds** — wasteful but symmetric, explicitly not part of this regression.

#### The fix

Cache built clients in `IdentityAwareBuilder`, keyed by a SHA-256 digest of the credential material that shaped the client (kubeconfig bytes, identity type/source, identity credential bytes). A credential change yields a new digest → fresh client. Token refresh needs no rebuild — all five identity wrappers (`gke`, `azure`, `upbound`, `aws`, `nebius`) install self-refreshing token sources behind `rc.Wrap` transports (**confirmed at source** for each). `singleflight` collapses the cold-cache thundering herd at provider start; the cache is LRU-bounded at 64 entries per builder.

**Tested (same cluster and load, 2026-08-07):** this branch restores the `v1.2.1` profile — slightly better, since one client per credential set also amortizes what `v1.2.1` rebuilt per reconcile — with 300/300 propagation:

```
fix (this PR):
phase             samples     avgMiB     maxMiB    maxCPUm
baseline                9      301.5      452.2      108.6
cache-settle           12      526.1      526.1        3.3
steady                 12      574.0      574.4      102.9
update-round-5          5      572.8      573.8      162.6
```

Post-run idle pod: `go_memstats_heap_sys_bytes` 612 MiB (vs 2154 MiB on `main`) — the ~2 GiB transient allocation spike never occurred at any point in the run; `go_goroutines` 723 (unchanged vs `main`'s 725).

**Open (untested):** lowering `--max-reconcile-rate` should bound the concurrent decodes and cap the spike on affected deployments, at the cost of throughput — plausible interim mitigation for CRD-heavy clusters, not measured.

#### Environment

- provider-kubernetes `main` @ `350ef9a` (regression) vs release `v1.2.1` (baseline); regression introduced by `b4bd483`
- controller-runtime `v0.23.1` (main) vs `v0.19.0` (v1.2.1); client-go `v0.35.1` vs `v0.33.0`; crossplane-runtime/v2 `v2.3.3` vs `v2.0.0-rc.1`; Go `1.26.5`
- kind `v1.36.1` (arm64, single node), UXP `v2.3.4-up.2`, 1572 CRDs, 3000 baggage `Secret`s
- provider flags: `--debug --enable-watches` (mechanism is watch-independent — the discovery happens in `Connect` — but all measurements were taken with watches enabled)

Author's note: measurements, analysis, and this description were prepared with Claude (Fable 5) under my direction during a load-testing session; the load-test harness and raw sample CSVs are available on request.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- Unit tests for the new cache: same-credentials client reuse, credential-change rebuild, and LRU eviction (`pkg/kube/client/cache_test.go`).
- Benchmarked on a kind cluster with 1572 CRDs, 3000 Secrets, and 300 watching `Object`s against `v1.2.1`, `main`, and this branch — full numbers above; this branch eliminates the ~2 GiB allocation spike and beats the `v1.2.1` baseline on steady memory and CPU with 300/300 propagation.
- Identity-wrapper code paths (`gke`, `azure`, `upbound`, `aws`, `nebius`) are confirmed cache-safe at source (self-refreshing token sources behind cached transports) but were not exercised live; the benchmark used kubeconfig-`Secret` credentials.

[contribution process]: https://git.io/fj2m9
