### PR TITLE
Fix per reconcile discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ spec:
   package: xpkg.crossplane.io/crossplane-contrib/provider-kubernetes:v1.0.0
 ```
 
+## Target cluster clients
+
+The provider builds one client per distinct ProviderConfig credential set
+(kubeconfig plus identity) and keeps it in an LRU cache bounded by
+`--client-cache-size` (default 8, `0` removes the bound). Building a client is
+expensive because its REST mapper primes itself with full aggregated discovery
+on first use, so size the cache to the number of distinct credential sets the
+provider talks to.
+
+Client-side rate limiting is disabled for these clients. A cached client is
+shared by every concurrent reconcile of its credential set, so client-go's
+per-client token bucket (5 QPS, burst 10) would serialize them. This applies to
+everything built from the same configuration: the reconcile client, the watch
+informers and the server-side apply discovery client. Load on the target
+cluster is bounded by `--max-reconcile-rate` on the provider side and by API
+Priority and Fairness on the API server.
+
 ## Developing locally
 
 See the header of [`go.mod`](./go.mod) for the minimum supported version of Go.

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -106,6 +107,7 @@ func main() {
 		// Additional legacy field managers to upgrade to Server-side apply field manager
 		legacyCSAFieldManagers = app.Flag("legacy-csa-field-managers", "Additional legacy client-side apply Kubernetes field manager names for upgrading to SSA field manager").Default().Strings()
 	)
+	app.Validate(func(*kingpin.Application) error { return validateClientCacheSize(*clientCacheSize) })
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
 	zl := zap.New(zap.UseDevMode(*debug), UseISO8601())
@@ -312,4 +314,13 @@ func canWatchCRD(ctx context.Context, mgr manager.Manager) (bool, error) {
 		}
 	}
 	return true, nil
+}
+
+// validateClientCacheSize rejects flag values that do not fit the builder's
+// int bound instead of letting the conversion wrap around.
+func validateClientCacheSize(size uint) error {
+	if size > math.MaxInt {
+		return errors.Errorf("--client-cache-size must not exceed %d", math.MaxInt)
+	}
+	return nil
 }

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -62,6 +63,7 @@ import (
 	controllerNamespaced "github.com/crossplane-contrib/provider-kubernetes/internal/controller/namespaced"
 	"github.com/crossplane-contrib/provider-kubernetes/internal/features"
 	"github.com/crossplane-contrib/provider-kubernetes/internal/version"
+	kubeclient "github.com/crossplane-contrib/provider-kubernetes/pkg/kube/client"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
@@ -89,6 +91,7 @@ func main() {
 		pollJitterPercentage    = app.Flag("poll-jitter-percentage", "Percentage of jitter to apply to poll interval. It cannot be negative, and must be less than 100.").Default("10").Uint()
 		leaderElection          = app.Flag("leader-election", "Use leader election for the controller manager.").Short('l').Default("false").Envar("LEADER_ELECTION").Bool()
 		maxReconcileRate        = app.Flag("max-reconcile-rate", "The number of concurrent reconciliations that may be running at one time.").Default("100").Int()
+		clientCacheSize         = app.Flag("client-cache-size", "Maximum number of cached target cluster clients, one per distinct ProviderConfig credential set; the least recently used client is evicted beyond this bound. 0 caches without bound.").Default(strconv.Itoa(kubeclient.DefaultClientCacheSize)).Envar("CLIENT_CACHE_SIZE").Uint()
 		sanitizeSecrets         = app.Flag("sanitize-secrets", "when enabled, redacts Secret data from Object status").Default("false").Envar("SANITIZE_SECRETS").Bool()
 		webhookPort             = app.Flag("webhook-port", "The port the webhook server listens on.").Default("9443").Envar("WEBHOOK_PORT").Int()
 		metricsBindAddress      = app.Flag("metrics-bind-address", "The address the metrics server listens on").Default(":8080").Envar("METRICS_BIND_ADDRESS").String()
@@ -200,6 +203,9 @@ func main() {
 		RemoveManagedFields:  *removeManagedFields,
 		PollJitter:           pollJitter,
 		PollJitterPercentage: *pollJitterPercentage,
+		ClientBuilder: kubeclient.NewIdentityAwareBuilder(mgr.GetClient(),
+			kubeclient.WithLogger(log),
+			kubeclient.WithClientCacheSize(int(*clientCacheSize))),
 	}
 
 	if *enableManagementPolicies {

--- a/internal/controller/cluster/kubernetes.go
+++ b/internal/controller/cluster/kubernetes.go
@@ -33,10 +33,10 @@ func Setup(mgr ctrl.Manager, o controller.Options, po pcontroller.Options) error
 	if err := config.Setup(mgr, o); err != nil {
 		return err
 	}
-	if err := object.Setup(mgr, o, po.SanitizeSecrets, po.RemoveManagedFields, po.PollJitterPercentage, po.LegacyCSAFieldManagers); err != nil {
+	if err := object.Setup(mgr, o, po.ClientBuilder, po.SanitizeSecrets, po.RemoveManagedFields, po.PollJitterPercentage, po.LegacyCSAFieldManagers); err != nil {
 		return err
 	}
-	if err := observedobjectcollection.Setup(mgr, o, po.PollJitter); err != nil {
+	if err := observedobjectcollection.Setup(mgr, o, po.ClientBuilder, po.PollJitter); err != nil {
 		return err
 	}
 	return nil
@@ -49,10 +49,10 @@ func SetupGated(mgr ctrl.Manager, o controller.Options, po pcontroller.Options) 
 	if err := config.SetupGated(mgr, o); err != nil {
 		return err
 	}
-	if err := object.SetupGated(mgr, o, po.SanitizeSecrets, po.RemoveManagedFields, po.PollJitterPercentage, po.LegacyCSAFieldManagers); err != nil {
+	if err := object.SetupGated(mgr, o, po.ClientBuilder, po.SanitizeSecrets, po.RemoveManagedFields, po.PollJitterPercentage, po.LegacyCSAFieldManagers); err != nil {
 		return err
 	}
-	if err := observedobjectcollection.SetupGated(mgr, o, po.PollJitter); err != nil {
+	if err := observedobjectcollection.SetupGated(mgr, o, po.ClientBuilder, po.PollJitter); err != nil {
 		return err
 	}
 	return nil

--- a/internal/controller/cluster/object/object.go
+++ b/internal/controller/cluster/object/object.go
@@ -153,7 +153,7 @@ type ResourceSyncer interface {
 }
 
 // Setup adds a controller that reconciles Object managed resources.
-func Setup(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, removeManagedFields bool, pollJitterPercentage uint, legacyCSAFieldManagers []string) error { // nolint:gocyclo // Too many branches due to alpha features, hopefully we can clean them up after we graduate them.
+func Setup(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Builder, sanitizeSecrets bool, removeManagedFields bool, pollJitterPercentage uint, legacyCSAFieldManagers []string) error { // nolint:gocyclo // Too many branches due to alpha features, hopefully we can clean them up after we graduate them.
 	name := managed.ControllerName(v1alpha2.ObjectGroupKind)
 	l := o.Logger.WithValues("controller", name)
 
@@ -182,7 +182,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, removeM
 		removeManagedFields: removeManagedFields,
 		kube:                mgr.GetClient(),
 		usage:               resource.NewLegacyProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
-		clientBuilder:       kubeclient.NewIdentityAwareBuilder(mgr.GetClient()),
+		clientBuilder:       clientBuilder,
 	}
 
 	if o.Features.Enabled(features.EnableBetaServerSideApply) {
@@ -257,9 +257,9 @@ func Setup(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, removeM
 
 // SetupGated registers a controller setup function that reconciles Object managed resources.
 // The controller setup is initiated after the CRD for Object becomes available.
-func SetupGated(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, removeManagedFields bool, pollJitterPercentage uint, legacyCSAFieldManagers []string) error {
+func SetupGated(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Builder, sanitizeSecrets bool, removeManagedFields bool, pollJitterPercentage uint, legacyCSAFieldManagers []string) error {
 	o.Gate.Register(func() {
-		if err := Setup(mgr, o, sanitizeSecrets, removeManagedFields, pollJitterPercentage, legacyCSAFieldManagers); err != nil {
+		if err := Setup(mgr, o, clientBuilder, sanitizeSecrets, removeManagedFields, pollJitterPercentage, legacyCSAFieldManagers); err != nil {
 			mgr.GetLogger().Error(err, "unable to setup reconciler", "gvk", v1alpha2.ObjectGroupVersionKind.String())
 		}
 	}, v1alpha2.ObjectGroupVersionKind)

--- a/internal/controller/cluster/object/object.go
+++ b/internal/controller/cluster/object/object.go
@@ -76,6 +76,7 @@ const (
 )
 
 const (
+	errNilClientBuilder  = "a client builder is required"
 	errGetProviderConfig = "cannot get provider config"
 	errTrackPCUsage      = "cannot track ProviderConfig usage"
 	errGetObject         = "cannot get object"
@@ -154,6 +155,9 @@ type ResourceSyncer interface {
 
 // Setup adds a controller that reconciles Object managed resources.
 func Setup(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Builder, sanitizeSecrets bool, removeManagedFields bool, pollJitterPercentage uint, legacyCSAFieldManagers []string) error { // nolint:gocyclo // Too many branches due to alpha features, hopefully we can clean them up after we graduate them.
+	if clientBuilder == nil {
+		return errors.New(errNilClientBuilder)
+	}
 	name := managed.ControllerName(v1alpha2.ObjectGroupKind)
 	l := o.Logger.WithValues("controller", name)
 
@@ -258,6 +262,9 @@ func Setup(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Buil
 // SetupGated registers a controller setup function that reconciles Object managed resources.
 // The controller setup is initiated after the CRD for Object becomes available.
 func SetupGated(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Builder, sanitizeSecrets bool, removeManagedFields bool, pollJitterPercentage uint, legacyCSAFieldManagers []string) error {
+	if clientBuilder == nil {
+		return errors.New(errNilClientBuilder)
+	}
 	o.Gate.Register(func() {
 		if err := Setup(mgr, o, clientBuilder, sanitizeSecrets, removeManagedFields, pollJitterPercentage, legacyCSAFieldManagers); err != nil {
 			mgr.GetLogger().Error(err, "unable to setup reconciler", "gvk", v1alpha2.ObjectGroupVersionKind.String())

--- a/internal/controller/cluster/observedobjectcollection/reconciler.go
+++ b/internal/controller/cluster/observedobjectcollection/reconciler.go
@@ -48,6 +48,7 @@ import (
 )
 
 const (
+	errNilClientBuilder           = "a client builder is required"
 	errGetProviderConfig          = "cannot get provider config"
 	errBuildKubeForProviderConfig = "cannot build kube client for provider config"
 	errStatusUpdate               = "cannot update status"
@@ -67,6 +68,9 @@ type Reconciler struct {
 
 // Setup adds a controller that reconciles ObservedObjectCollection resources.
 func Setup(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Builder, pollJitter time.Duration) error {
+	if clientBuilder == nil {
+		return errors.New(errNilClientBuilder)
+	}
 	name := managed.ControllerName(v1alpha1.ObservedObjectCollectionGroupKind)
 
 	r := &Reconciler{
@@ -90,6 +94,9 @@ func Setup(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Buil
 // ObservedObjectCollection managed resources. The controller setup is
 // initiated after the CRD for ObservedObjectCollection becomes available.
 func SetupGated(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Builder, pollJitter time.Duration) error {
+	if clientBuilder == nil {
+		return errors.New(errNilClientBuilder)
+	}
 	o.Gate.Register(func() {
 		if err := Setup(mgr, o, clientBuilder, pollJitter); err != nil {
 			mgr.GetLogger().Error(err, "unable to setup reconciler", "gvk", v1alpha1.ObservedObjectCollectionGroupVersionKind.String())

--- a/internal/controller/cluster/observedobjectcollection/reconciler.go
+++ b/internal/controller/cluster/observedobjectcollection/reconciler.go
@@ -66,7 +66,7 @@ type Reconciler struct {
 }
 
 // Setup adds a controller that reconciles ObservedObjectCollection resources.
-func Setup(mgr ctrl.Manager, o controller.Options, pollJitter time.Duration) error {
+func Setup(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Builder, pollJitter time.Duration) error {
 	name := managed.ControllerName(v1alpha1.ObservedObjectCollectionGroupKind)
 
 	r := &Reconciler{
@@ -75,7 +75,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, pollJitter time.Duration) err
 		pollInterval: func() time.Duration {
 			return o.PollInterval + +time.Duration((rand.Float64()-0.5)*2*float64(pollJitter)) //nolint
 		},
-		clientBuilder:      kubeclient.NewIdentityAwareBuilder(mgr.GetClient()),
+		clientBuilder:      clientBuilder,
 		observedObjectName: observedObjectName,
 	}
 
@@ -89,9 +89,9 @@ func Setup(mgr ctrl.Manager, o controller.Options, pollJitter time.Duration) err
 // SetupGated registers a controller setup function that reconciles
 // ObservedObjectCollection managed resources. The controller setup is
 // initiated after the CRD for ObservedObjectCollection becomes available.
-func SetupGated(mgr ctrl.Manager, o controller.Options, pollJitter time.Duration) error {
+func SetupGated(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Builder, pollJitter time.Duration) error {
 	o.Gate.Register(func() {
-		if err := Setup(mgr, o, pollJitter); err != nil {
+		if err := Setup(mgr, o, clientBuilder, pollJitter); err != nil {
 			mgr.GetLogger().Error(err, "unable to setup reconciler", "gvk", v1alpha1.ObservedObjectCollectionGroupVersionKind.String())
 		}
 	}, v1alpha1.ObservedObjectCollectionGroupVersionKind)

--- a/internal/controller/namespaced/kubernetes.go
+++ b/internal/controller/namespaced/kubernetes.go
@@ -33,10 +33,10 @@ func Setup(mgr ctrl.Manager, o controller.Options, po pcontroller.Options) error
 	if err := config.Setup(mgr, o); err != nil {
 		return err
 	}
-	if err := object.Setup(mgr, o, po.SanitizeSecrets, po.RemoveManagedFields, po.PollJitterPercentage, po.LegacyCSAFieldManagers); err != nil {
+	if err := object.Setup(mgr, o, po.ClientBuilder, po.SanitizeSecrets, po.RemoveManagedFields, po.PollJitterPercentage, po.LegacyCSAFieldManagers); err != nil {
 		return err
 	}
-	if err := observedobjectcollection.Setup(mgr, o, po.PollJitter); err != nil {
+	if err := observedobjectcollection.Setup(mgr, o, po.ClientBuilder, po.PollJitter); err != nil {
 		return err
 	}
 	return nil
@@ -49,10 +49,10 @@ func SetupGated(mgr ctrl.Manager, o controller.Options, po pcontroller.Options) 
 	if err := config.SetupGated(mgr, o); err != nil {
 		return err
 	}
-	if err := object.SetupGated(mgr, o, po.SanitizeSecrets, po.RemoveManagedFields, po.PollJitterPercentage, po.LegacyCSAFieldManagers); err != nil {
+	if err := object.SetupGated(mgr, o, po.ClientBuilder, po.SanitizeSecrets, po.RemoveManagedFields, po.PollJitterPercentage, po.LegacyCSAFieldManagers); err != nil {
 		return err
 	}
-	if err := observedobjectcollection.SetupGated(mgr, o, po.PollJitter); err != nil {
+	if err := observedobjectcollection.SetupGated(mgr, o, po.ClientBuilder, po.PollJitter); err != nil {
 		return err
 	}
 	return nil

--- a/internal/controller/namespaced/object/object.go
+++ b/internal/controller/namespaced/object/object.go
@@ -154,7 +154,7 @@ type ResourceSyncer interface {
 }
 
 // Setup adds a controller that reconciles Object managed resources.
-func Setup(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, removeManagedFields bool, pollJitterPercentage uint, legacyCSAFieldManagers []string) error { // nolint:gocyclo // Too many branches due to alpha features, hopefully we can clean them up after we graduate them.
+func Setup(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Builder, sanitizeSecrets bool, removeManagedFields bool, pollJitterPercentage uint, legacyCSAFieldManagers []string) error { // nolint:gocyclo // Too many branches due to alpha features, hopefully we can clean them up after we graduate them.
 	name := managed.ControllerName(v1alpha1.ObjectGroupKind)
 	l := o.Logger.WithValues("controller", name)
 
@@ -183,7 +183,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, removeM
 		removeManagedFields: removeManagedFields,
 		kube:                mgr.GetClient(),
 		usage:               resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
-		clientBuilder:       kubeclient.NewIdentityAwareBuilder(mgr.GetClient()),
+		clientBuilder:       clientBuilder,
 	}
 
 	if o.Features.Enabled(features.EnableBetaServerSideApply) {
@@ -258,9 +258,9 @@ func Setup(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, removeM
 
 // SetupGated registers a gated controller that reconciles Object managed resources.
 // The controller setup is initiated after the CRD for Object becomes available.
-func SetupGated(mgr ctrl.Manager, o controller.Options, sanitizeSecrets bool, removeManagedFields bool, pollJitterPercentage uint, legacyCSAFieldManagers []string) error {
+func SetupGated(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Builder, sanitizeSecrets bool, removeManagedFields bool, pollJitterPercentage uint, legacyCSAFieldManagers []string) error {
 	o.Gate.Register(func() {
-		if err := Setup(mgr, o, sanitizeSecrets, removeManagedFields, pollJitterPercentage, legacyCSAFieldManagers); err != nil {
+		if err := Setup(mgr, o, clientBuilder, sanitizeSecrets, removeManagedFields, pollJitterPercentage, legacyCSAFieldManagers); err != nil {
 			mgr.GetLogger().Error(err, "unable to setup reconciler", "gvk", v1alpha1.ObjectGroupVersionKind.String())
 		}
 	}, v1alpha1.ObjectGroupVersionKind)

--- a/internal/controller/namespaced/object/object.go
+++ b/internal/controller/namespaced/object/object.go
@@ -77,6 +77,7 @@ const (
 )
 
 const (
+	errNilClientBuilder  = "a client builder is required"
 	errGetProviderConfig = "cannot get provider config"
 	errTrackPCUsage      = "cannot track ProviderConfig usage"
 	errGetObject         = "cannot get object"
@@ -155,6 +156,9 @@ type ResourceSyncer interface {
 
 // Setup adds a controller that reconciles Object managed resources.
 func Setup(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Builder, sanitizeSecrets bool, removeManagedFields bool, pollJitterPercentage uint, legacyCSAFieldManagers []string) error { // nolint:gocyclo // Too many branches due to alpha features, hopefully we can clean them up after we graduate them.
+	if clientBuilder == nil {
+		return errors.New(errNilClientBuilder)
+	}
 	name := managed.ControllerName(v1alpha1.ObjectGroupKind)
 	l := o.Logger.WithValues("controller", name)
 
@@ -259,6 +263,9 @@ func Setup(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Buil
 // SetupGated registers a gated controller that reconciles Object managed resources.
 // The controller setup is initiated after the CRD for Object becomes available.
 func SetupGated(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Builder, sanitizeSecrets bool, removeManagedFields bool, pollJitterPercentage uint, legacyCSAFieldManagers []string) error {
+	if clientBuilder == nil {
+		return errors.New(errNilClientBuilder)
+	}
 	o.Gate.Register(func() {
 		if err := Setup(mgr, o, clientBuilder, sanitizeSecrets, removeManagedFields, pollJitterPercentage, legacyCSAFieldManagers); err != nil {
 			mgr.GetLogger().Error(err, "unable to setup reconciler", "gvk", v1alpha1.ObjectGroupVersionKind.String())

--- a/internal/controller/namespaced/observedobjectcollection/reconciler.go
+++ b/internal/controller/namespaced/observedobjectcollection/reconciler.go
@@ -67,7 +67,7 @@ type Reconciler struct {
 }
 
 // Setup adds a controller that reconciles ObservedObjectCollection resources.
-func Setup(mgr ctrl.Manager, o controller.Options, pollJitter time.Duration) error {
+func Setup(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Builder, pollJitter time.Duration) error {
 	name := managed.ControllerName(observedobjectcollectionv1alpha1.ObservedObjectCollectionGroupKind)
 
 	r := &Reconciler{
@@ -76,7 +76,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, pollJitter time.Duration) err
 		pollInterval: func() time.Duration {
 			return o.PollInterval + +time.Duration((rand.Float64()-0.5)*2*float64(pollJitter)) //nolint
 		},
-		clientBuilder:      kubeclient.NewIdentityAwareBuilder(mgr.GetClient()),
+		clientBuilder:      clientBuilder,
 		observedObjectName: observedObjectName,
 	}
 
@@ -90,9 +90,9 @@ func Setup(mgr ctrl.Manager, o controller.Options, pollJitter time.Duration) err
 // SetupGated registers a controller setup function that reconciles
 // ObservedObjectCollection managed resources. The controller setup is
 // initiated after the CRD for ObservedObjectCollection becomes available.
-func SetupGated(mgr ctrl.Manager, o controller.Options, pollJitter time.Duration) error {
+func SetupGated(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Builder, pollJitter time.Duration) error {
 	o.Gate.Register(func() {
-		if err := Setup(mgr, o, pollJitter); err != nil {
+		if err := Setup(mgr, o, clientBuilder, pollJitter); err != nil {
 			mgr.GetLogger().Error(err, "unable to setup reconciler", "gvk", observedobjectcollectionv1alpha1.ObservedObjectCollectionGroupVersionKind.String())
 		}
 	}, observedobjectcollectionv1alpha1.ObservedObjectCollectionGroupVersionKind)

--- a/internal/controller/namespaced/observedobjectcollection/reconciler.go
+++ b/internal/controller/namespaced/observedobjectcollection/reconciler.go
@@ -49,6 +49,7 @@ import (
 )
 
 const (
+	errNilClientBuilder           = "a client builder is required"
 	errGetProviderConfig          = "cannot get provider config"
 	errBuildKubeForProviderConfig = "cannot build kube client for provider config"
 	errStatusUpdate               = "cannot update status"
@@ -68,6 +69,9 @@ type Reconciler struct {
 
 // Setup adds a controller that reconciles ObservedObjectCollection resources.
 func Setup(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Builder, pollJitter time.Duration) error {
+	if clientBuilder == nil {
+		return errors.New(errNilClientBuilder)
+	}
 	name := managed.ControllerName(observedobjectcollectionv1alpha1.ObservedObjectCollectionGroupKind)
 
 	r := &Reconciler{
@@ -91,6 +95,9 @@ func Setup(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Buil
 // ObservedObjectCollection managed resources. The controller setup is
 // initiated after the CRD for ObservedObjectCollection becomes available.
 func SetupGated(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Builder, pollJitter time.Duration) error {
+	if clientBuilder == nil {
+		return errors.New(errNilClientBuilder)
+	}
 	o.Gate.Register(func() {
 		if err := Setup(mgr, o, clientBuilder, pollJitter); err != nil {
 			mgr.GetLogger().Error(err, "unable to setup reconciler", "gvk", observedobjectcollectionv1alpha1.ObservedObjectCollectionGroupVersionKind.String())

--- a/internal/controller/options.go
+++ b/internal/controller/options.go
@@ -18,6 +18,8 @@ package controller
 
 import (
 	"time"
+
+	kubeclient "github.com/crossplane-contrib/provider-kubernetes/pkg/kube/client"
 )
 
 // Options holds the configuration options for the provider controllers
@@ -27,4 +29,8 @@ type Options struct {
 	PollJitter             time.Duration
 	PollJitterPercentage   uint
 	LegacyCSAFieldManagers []string
+	// ClientBuilder builds clients for the target clusters referenced by
+	// ProviderConfigs. It is shared by all controllers so that its client
+	// cache is shared too.
+	ClientBuilder kubeclient.Builder
 }

--- a/pkg/kube/client/aws/aws.go
+++ b/pkg/kube/client/aws/aws.go
@@ -61,7 +61,6 @@ func WrapRESTConfig(ctx context.Context, rc *rest.Config, clusterNameFromKubecon
 
 	// Create a token source that generates EKS tokens on demand
 	tokenSource := &eksTokenSource{
-		ctx:       ctx,
 		stsClient: stsClient,
 		clusterID: clusterName,
 	}
@@ -105,9 +104,13 @@ func extractClusterNameFromARN(arnString string) (string, error) {
 	return parts[len(parts)-1], nil
 }
 
+// tokenSource issues an EKS bearer token for the request carrying ctx.
+type tokenSource interface {
+	Token(ctx context.Context) (string, error)
+}
+
 // eksTokenSource generates EKS authentication tokens using AWS STS
 type eksTokenSource struct {
-	ctx       context.Context
 	stsClient *sts.Client
 	clusterID string
 }
@@ -115,8 +118,11 @@ type eksTokenSource struct {
 // Token generates an EKS authentication token
 // This replicates the behavior of `aws eks get-token` command
 // The STS client uses credentials from the AWS default credentials chain,
-// which includes assumed role credentials from Web Identity/IRSA
-func (s *eksTokenSource) Token() (string, error) {
+// which includes assumed role credentials from Web Identity/IRSA.
+// ctx is the context of the request being authenticated: the wrapped REST
+// config outlives the reconcile that built it (cached clients, long-lived
+// informers), so the token source must not hold on to a context of its own.
+func (s *eksTokenSource) Token(ctx context.Context) (string, error) {
 	// Create a presigned request for GetCallerIdentity
 	// This is what EKS uses for authentication
 	// Default expiration is 15 minutes (900 seconds) which is what EKS expects
@@ -124,7 +130,7 @@ func (s *eksTokenSource) Token() (string, error) {
 
 	// Create presigned request with cluster ID and expiration headers
 	// This matches the provider-aws implementation exactly
-	presignedReq, err := presigner.PresignGetCallerIdentity(s.ctx,
+	presignedReq, err := presigner.PresignGetCallerIdentity(ctx,
 		&sts.GetCallerIdentityInput{},
 		func(po *sts.PresignOptions) {
 			po.ClientOptions = []func(*sts.Options){
@@ -146,13 +152,13 @@ func (s *eksTokenSource) Token() (string, error) {
 
 // bearerAuthRoundTripper injects a bearer token into HTTP requests
 type bearerAuthRoundTripper struct {
-	source *eksTokenSource
+	source tokenSource
 	rt     http.RoundTripper
 }
 
 // RoundTrip implements http.RoundTripper
 func (b *bearerAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	token, err := b.source.Token()
+	token, err := b.source.Token(req.Context())
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get EKS token")
 	}

--- a/pkg/kube/client/aws/aws_test.go
+++ b/pkg/kube/client/aws/aws_test.go
@@ -1,7 +1,14 @@
 package aws
 
 import (
+	"context"
+	"net/http"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 )
 
 func Test_extractClusterNameFromARN(t *testing.T) {
@@ -58,6 +65,93 @@ func Test_extractClusterNameFromARN(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("extractClusterNameFromARN() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type ctxKey struct{}
+
+type fakeTokenSource struct {
+	token string
+	err   error
+	// seen is the value of ctxKey carried by the context Token was called with.
+	seen any
+}
+
+func (f *fakeTokenSource) Token(ctx context.Context) (string, error) {
+	f.seen = ctx.Value(ctxKey{})
+	return f.token, f.err
+}
+
+type recordingRoundTripper struct {
+	authorization string
+}
+
+func (r *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.authorization = req.Header.Get("Authorization")
+	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
+}
+
+func TestBearerAuthRoundTripper(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	type args struct {
+		source *fakeTokenSource
+		ctx    context.Context
+	}
+	type want struct {
+		authorization string
+		seen          any
+		err           error
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"TokenIssuedForRequestContext": {
+			args: args{
+				source: &fakeTokenSource{token: "k8s-aws-v1.token"},
+				ctx:    context.WithValue(context.Background(), ctxKey{}, "request"),
+			},
+			want: want{
+				authorization: "Bearer k8s-aws-v1.token",
+				seen:          "request",
+			},
+		},
+		"TokenError": {
+			args: args{
+				source: &fakeTokenSource{err: errBoom},
+				ctx:    context.Background(),
+			},
+			want: want{
+				err: errors.Wrap(errBoom, "failed to get EKS token"),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			rt := &recordingRoundTripper{}
+			b := &bearerAuthRoundTripper{source: tc.args.source, rt: rt}
+
+			req, err := http.NewRequestWithContext(tc.args.ctx, http.MethodGet, "https://eks.example.org/api", nil)
+			if err != nil {
+				t.Fatalf("NewRequestWithContext(...): unexpected error: %v", err)
+			}
+			resp, err := b.RoundTrip(req)
+			if resp != nil {
+				_ = resp.Body.Close()
+			}
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("RoundTrip(...): -want error, +got error:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.authorization, rt.authorization); diff != "" {
+				t.Errorf("RoundTrip(...): -want authorization, +got authorization:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.seen, tc.args.source.seen); diff != "" {
+				t.Errorf("RoundTrip(...): -want token source context value, +got:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/kube/client/cache_test.go
+++ b/pkg/kube/client/cache_test.go
@@ -185,6 +185,17 @@ func TestKubeForProviderConfigCaching(t *testing.T) {
 			},
 			want: want{clients: []int{0, 1, 2}},
 		},
+		"NegativeSizeCachesWithoutBound": {
+			args: args{
+				cacheSize: -1,
+				calls: []kconfig.ProviderConfigSpec{
+					pcSpec("kubeconfig-a", ""),
+					pcSpec("kubeconfig-b", ""),
+					pcSpec("kubeconfig-a", ""),
+				},
+			},
+			want: want{clients: []int{0, 1, 0}},
+		},
 	}
 
 	for name, tc := range cases {

--- a/pkg/kube/client/cache_test.go
+++ b/pkg/kube/client/cache_test.go
@@ -1,0 +1,417 @@
+/*
+Copyright 2026 The Crossplane Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
+
+	kconfig "github.com/crossplane-contrib/provider-kubernetes/pkg/kube/config"
+)
+
+const testNamespace = "crossplane-system"
+
+func kubeconfigFor(server string) []byte {
+	return fmt.Appendf(nil, `apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    server: %s
+contexts:
+- name: ctx
+  context:
+    cluster: c
+    user: u
+current-context: ctx
+users:
+- name: u
+  user: {}
+`, server)
+}
+
+// secretLocalClient serves the supplied Secrets, keyed by name, from the
+// local cluster.
+func secretLocalClient(secrets map[string]map[string][]byte) client.Client {
+	return &test.MockClient{
+		MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+			s, ok := obj.(*corev1.Secret)
+			if !ok {
+				return fmt.Errorf("unexpected object type %T", obj)
+			}
+			data, ok := secrets[key.Name]
+			if !ok {
+				return fmt.Errorf("no secret %q", key.Name)
+			}
+			s.Data = data
+			return nil
+		},
+	}
+}
+
+func secretSelector(name, key string) xpv2.CommonCredentialSelectors {
+	return xpv2.CommonCredentialSelectors{
+		SecretRef: &xpv2.SecretKeySelector{
+			SecretReference: xpv2.SecretReference{Name: name, Namespace: testNamespace},
+			Key:             key,
+		},
+	}
+}
+
+// pcSpec references the kubeconfig Secret and, when identitySecret is set, a
+// Google Application Credentials identity Secret.
+func pcSpec(kubeconfigSecret, identitySecret string) kconfig.ProviderConfigSpec {
+	pc := kconfig.ProviderConfigSpec{
+		Credentials: kconfig.ProviderCredentials{
+			Source:                    xpv2.CredentialsSourceSecret,
+			CommonCredentialSelectors: secretSelector(kubeconfigSecret, "kubeconfig"),
+		},
+	}
+	if identitySecret != "" {
+		pc.Identity = &kconfig.Identity{
+			Type: kconfig.IdentityTypeGoogleApplicationCredentials,
+			ProviderCredentials: kconfig.ProviderCredentials{
+				Source:                    xpv2.CredentialsSourceSecret,
+				CommonCredentialSelectors: secretSelector(identitySecret, "credentials"),
+			},
+		}
+	}
+	return pc
+}
+
+// clientIdentities maps every client to the index of the first call that
+// returned the same instance, so [0, 0] means one reused client and [0, 1]
+// means two distinct clients.
+func clientIdentities(clients []client.Client) []int {
+	ids := make([]int, len(clients))
+	for i, c := range clients {
+		ids[i] = i
+		for j := range i {
+			if clients[j] == c {
+				ids[i] = ids[j]
+				break
+			}
+		}
+	}
+	return ids
+}
+
+func TestKubeForProviderConfigCaching(t *testing.T) {
+	kubeconfigA := kubeconfigFor("https://a.example.org:6443")
+	kubeconfigB := kubeconfigFor("https://b.example.org:6443")
+	secrets := map[string]map[string][]byte{
+		"kubeconfig-a": {"kubeconfig": kubeconfigA},
+		"kubeconfig-b": {"kubeconfig": kubeconfigB},
+		// Non-JSON Google credentials are used verbatim as a static access
+		// token, so no token endpoint is involved.
+		"token-a": {"credentials": []byte("access-token-a")},
+		"token-b": {"credentials": []byte("access-token-b")},
+	}
+
+	type args struct {
+		cacheSize int
+		calls     []kconfig.ProviderConfigSpec
+	}
+	type want struct {
+		clients []int
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"SameCredentialsReuseClient": {
+			args: args{
+				cacheSize: DefaultClientCacheSize,
+				calls:     []kconfig.ProviderConfigSpec{pcSpec("kubeconfig-a", ""), pcSpec("kubeconfig-a", "")},
+			},
+			want: want{clients: []int{0, 0}},
+		},
+		"DifferentKubeconfigBuildsNewClient": {
+			args: args{
+				cacheSize: DefaultClientCacheSize,
+				calls:     []kconfig.ProviderConfigSpec{pcSpec("kubeconfig-a", ""), pcSpec("kubeconfig-b", "")},
+			},
+			want: want{clients: []int{0, 1}},
+		},
+		"SameKubeconfigDifferentIdentityBuildsNewClient": {
+			args: args{
+				cacheSize: DefaultClientCacheSize,
+				calls: []kconfig.ProviderConfigSpec{
+					pcSpec("kubeconfig-a", ""),
+					pcSpec("kubeconfig-a", "token-a"),
+					pcSpec("kubeconfig-a", "token-b"),
+					pcSpec("kubeconfig-a", "token-a"),
+				},
+			},
+			want: want{clients: []int{0, 1, 2, 1}},
+		},
+		"LeastRecentlyUsedClientIsEvicted": {
+			args: args{
+				cacheSize: 1,
+				calls: []kconfig.ProviderConfigSpec{
+					pcSpec("kubeconfig-a", ""),
+					pcSpec("kubeconfig-b", ""),
+					pcSpec("kubeconfig-a", ""),
+				},
+			},
+			want: want{clients: []int{0, 1, 2}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			b := NewIdentityAwareBuilder(secretLocalClient(secrets), WithClientCacheSize(tc.args.cacheSize))
+
+			clients := make([]client.Client, 0, len(tc.args.calls))
+			for i, pc := range tc.args.calls {
+				k, _, err := b.KubeForProviderConfig(context.Background(), pc)
+				if err != nil {
+					t.Fatalf("KubeForProviderConfig(...) call %d: unexpected error: %v", i, err)
+				}
+				clients = append(clients, k)
+			}
+
+			if diff := cmp.Diff(tc.want.clients, clientIdentities(clients)); diff != "" {
+				t.Errorf("KubeForProviderConfig(...): -want client identities, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestKubeForProviderConfigConcurrentBuildsCollapse(t *testing.T) {
+	const callers = 16
+	secrets := map[string]map[string][]byte{
+		"kubeconfig": {"kubeconfig": kubeconfigFor("https://example.org:6443")},
+	}
+
+	var builds atomic.Int32
+	b := NewIdentityAwareBuilder(secretLocalClient(secrets))
+	b.newClient = func(rc *rest.Config) (client.Client, error) {
+		builds.Add(1)
+		// Hold the build so that the concurrent callers pile up behind it
+		// instead of finding the finished client in the cache.
+		time.Sleep(50 * time.Millisecond)
+		return client.New(rc, client.Options{})
+	}
+
+	clients := make([]client.Client, callers)
+	errs := make([]error, callers)
+	var wg sync.WaitGroup
+	for i := range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			clients[i], _, errs[i] = b.KubeForProviderConfig(context.Background(), pcSpec("kubeconfig", ""))
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("KubeForProviderConfig(...) caller %d: unexpected error: %v", i, err)
+		}
+	}
+	if diff := cmp.Diff(make([]int, callers), clientIdentities(clients)); diff != "" {
+		t.Errorf("KubeForProviderConfig(...): -want every caller to share one client, +got:\n%s", diff)
+	}
+	if diff := cmp.Diff(int32(1), builds.Load()); diff != "" {
+		t.Errorf("KubeForProviderConfig(...): -want builds, +got builds:\n%s", diff)
+	}
+}
+
+// TestKubeForProviderConfigOutlivesContext guards against the cached client
+// inheriting the reconcile context: crossplane-runtime cancels it once the
+// reconcile returns, and the identity token sources must keep working for
+// every later reconcile that reuses the client.
+func TestKubeForProviderConfigOutlivesContext(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"sts-token","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer tokenServer.Close()
+
+	var authorization atomic.Pointer[string]
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := r.Header.Get("Authorization")
+		authorization.Store(&h)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer apiServer.Close()
+
+	subjectTokenFile := filepath.Join(t.TempDir(), "subject-token")
+	if err := os.WriteFile(subjectTokenFile, []byte("subject-token"), 0o600); err != nil {
+		t.Fatalf("WriteFile(...): unexpected error: %v", err)
+	}
+	// External account (workload identity federation) credentials exchange
+	// the subject token at token_url on every refresh, using the context the
+	// token source was created with.
+	credentials := fmt.Appendf(nil, `{
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/projects/1/locations/global/workloadIdentityPools/pool/providers/provider",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+  "token_url": %q,
+  "credential_source": {"file": %q}
+}`, tokenServer.URL, subjectTokenFile)
+	secrets := map[string]map[string][]byte{
+		"kubeconfig": {"kubeconfig": kubeconfigFor(apiServer.URL)},
+		"gcp":        {"credentials": credentials},
+	}
+
+	b := NewIdentityAwareBuilder(secretLocalClient(secrets))
+	reconcileCtx, cancel := context.WithCancel(context.Background())
+	_, rc, err := b.KubeForProviderConfig(reconcileCtx, pcSpec("kubeconfig", "gcp"))
+	if err != nil {
+		t.Fatalf("KubeForProviderConfig(...): unexpected error: %v", err)
+	}
+	cancel()
+
+	hc, err := rest.HTTPClientFor(rc)
+	if err != nil {
+		t.Fatalf("rest.HTTPClientFor(...): unexpected error: %v", err)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, apiServer.URL+"/version", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequestWithContext(...): unexpected error: %v", err)
+	}
+	resp, err := hc.Do(req)
+	if err != nil {
+		t.Fatalf("request through the cached REST config after its reconcile context was cancelled: unexpected error: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	got := authorization.Load()
+	if got == nil {
+		t.Fatal("expected the request to reach the API server")
+	}
+	if diff := cmp.Diff("Bearer sts-token", *got); diff != "" {
+		t.Errorf("request authorization: -want, +got:\n%s", diff)
+	}
+}
+
+func TestDigestWrite(t *testing.T) {
+	digestOf := func(material ...[]byte) string {
+		d := sha256.New()
+		digestWrite(d, material...)
+		return hex.EncodeToString(d.Sum(nil))
+	}
+
+	type args struct {
+		first  [][]byte
+		second [][]byte
+	}
+	type want struct {
+		equal bool
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"SameMaterialSameDigest": {
+			args: args{
+				first:  [][]byte{[]byte("a"), []byte("b")},
+				second: [][]byte{[]byte("a"), []byte("b")},
+			},
+			want: want{equal: true},
+		},
+		"FieldBoundariesDoNotAlias": {
+			args: args{
+				first:  [][]byte{[]byte("ab"), []byte("c")},
+				second: [][]byte{[]byte("a"), []byte("bc")},
+			},
+			want: want{equal: false},
+		},
+		"EmbeddedDelimitersDoNotAlias": {
+			args: args{
+				first:  [][]byte{[]byte("a\x00b"), []byte("c")},
+				second: [][]byte{[]byte("a"), []byte("b\x00c")},
+			},
+			want: want{equal: false},
+		},
+		"EmptyFieldIsSignificant": {
+			args: args{
+				first:  [][]byte{[]byte("a"), {}},
+				second: [][]byte{[]byte("a")},
+			},
+			want: want{equal: false},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := digestOf(tc.args.first...) == digestOf(tc.args.second...)
+			if diff := cmp.Diff(tc.want.equal, got); diff != "" {
+				t.Errorf("digestWrite(...): -want equal digests, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestKubeForProviderConfigRESTConfig(t *testing.T) {
+	secrets := map[string]map[string][]byte{
+		"kubeconfig": {"kubeconfig": kubeconfigFor("https://example.org:6443")},
+	}
+
+	type want struct {
+		qps          float32
+		sharedConfig bool
+	}
+	cases := map[string]struct {
+		want want
+	}{
+		"ThrottlingDisabledAndConfigCopied": {
+			want: want{qps: -1, sharedConfig: false},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			b := NewIdentityAwareBuilder(secretLocalClient(secrets))
+
+			_, first, err := b.KubeForProviderConfig(context.Background(), pcSpec("kubeconfig", ""))
+			if err != nil {
+				t.Fatalf("first KubeForProviderConfig(...): unexpected error: %v", err)
+			}
+			_, second, err := b.KubeForProviderConfig(context.Background(), pcSpec("kubeconfig", ""))
+			if err != nil {
+				t.Fatalf("second KubeForProviderConfig(...): unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.want.qps, first.QPS); diff != "" {
+				t.Errorf("KubeForProviderConfig(...): -want QPS, +got QPS:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.sharedConfig, first == second); diff != "" {
+				t.Errorf("KubeForProviderConfig(...): -want shared *rest.Config, +got:\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/kube/client/client.go
+++ b/pkg/kube/client/client.go
@@ -15,16 +15,23 @@ package client
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"hash"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sync/singleflight"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/utils/lru"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
 
@@ -66,39 +73,131 @@ func (fn BuilderFn) KubeForProviderConfig(ctx context.Context, pc kconfig.Provid
 	return fn(ctx, pc)
 }
 
+// DefaultClientCacheSize is the default bound on the number of target cluster
+// clients an IdentityAwareBuilder keeps, one per distinct credential set.
+const DefaultClientCacheSize = 8
+
 // IdentityAwareBuilder is a Builder that can inject identity credentials into
 // the REST config of a Kubernetes client.
 type IdentityAwareBuilder struct {
 	local       client.Client
+	log         logging.Logger
 	store       *token.ReuseSourceStore
 	nebiusStore *nebius.SDKStore
+
+	// clients caches built clients keyed by a digest of the credential
+	// material that produced them, see KubeForProviderConfig.
+	clients   *lru.Cache
+	cacheSize int
+	building  singleflight.Group
+	newClient func(rc *rest.Config) (client.Client, error)
+}
+
+// cachedClient is a client together with the REST config it was built from.
+type cachedClient struct {
+	kube client.Client
+	rc   *rest.Config
+}
+
+// BuilderOption configures an IdentityAwareBuilder.
+type BuilderOption func(*IdentityAwareBuilder)
+
+// WithLogger sets the logger the builder reports client cache activity to.
+func WithLogger(l logging.Logger) BuilderOption {
+	return func(b *IdentityAwareBuilder) {
+		b.log = l
+	}
+}
+
+// WithClientCacheSize bounds the number of cached target cluster clients, one
+// per distinct credential set; the least recently used client is evicted
+// beyond the bound. A size of 0 removes the bound.
+func WithClientCacheSize(size int) BuilderOption {
+	return func(b *IdentityAwareBuilder) {
+		b.cacheSize = size
+	}
 }
 
 // NewIdentityAwareBuilder returns a new IdentityAwareBuilder.
-func NewIdentityAwareBuilder(local client.Client) *IdentityAwareBuilder {
-	return &IdentityAwareBuilder{
+func NewIdentityAwareBuilder(local client.Client, opts ...BuilderOption) *IdentityAwareBuilder {
+	b := &IdentityAwareBuilder{
 		local:       local,
+		log:         logging.NewNopLogger(),
 		store:       token.NewReuseSourceStore(),
 		nebiusStore: nebius.NewSDKStore(),
+		cacheSize:   DefaultClientCacheSize,
+		newClient: func(rc *rest.Config) (client.Client, error) {
+			return client.New(rc, client.Options{})
+		},
 	}
+	for _, o := range opts {
+		o(b)
+	}
+	b.clients = lru.NewWithEvictionFunc(b.cacheSize, func(lru.Key, any) {
+		b.log.Debug("Evicted least recently used target cluster client", "cacheSize", b.cacheSize)
+	})
+	return b
 }
 
 // KubeForProviderConfig returns the kube client and *rest.config for the given
-// provider config.
+// provider config. Clients are cached by a digest of the credential material
+// that produced them: a fresh client is expensive because its RESTMapper
+// primes itself via aggregated discovery on the first mapping lookup (the
+// whole API surface, multi-megabyte on CRD-heavy clusters), and this method
+// is called on every reconcile. A credential change yields a new digest and
+// thus a fresh client; token refresh happens inside the cached transports and
+// needs no rebuild.
 func (b *IdentityAwareBuilder) KubeForProviderConfig(ctx context.Context, pc kconfig.ProviderConfigSpec) (client.Client, *rest.Config, error) {
-	rc, err := b.restForProviderConfig(ctx, pc)
+	digest := sha256.New()
+	rc, err := b.restForProviderConfig(ctx, pc, digest)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "cannot get REST config for provider")
+		return nil, nil, errors.Wrap(err, "cannot get REST config for provider")
 	}
-	k, err := client.New(rc, client.Options{})
+	key := hex.EncodeToString(digest.Sum(nil))
+	if v, ok := b.clients.Get(key); ok {
+		cached := v.(cachedClient)
+		return cached.kube, rest.CopyConfig(cached.rc), nil
+	}
+	// singleflight collapses the thundering herd of concurrent reconciles
+	// racing to build the same client on a cold cache (e.g. provider start).
+	v, err, _ := b.building.Do(key, func() (any, error) {
+		if v, ok := b.clients.Get(key); ok {
+			return v, nil
+		}
+		k, err := b.newClient(rc)
+		if err != nil {
+			return nil, err
+		}
+		cached := cachedClient{kube: k, rc: rc}
+		b.clients.Add(key, cached)
+		b.log.Debug("Built target cluster client", "cachedClients", b.clients.Len(), "cacheSize", b.cacheSize)
+		return cached, nil
+	})
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "cannot create Kubernetes client for provider")
+		return nil, nil, errors.Wrap(err, "cannot create Kubernetes client for provider")
 	}
-	return k, rc, nil
+	cached := v.(cachedClient)
+	// The config is shared by every caller of this credential set; hand out a
+	// copy so that nobody can mutate it underneath the cached client.
+	return cached.kube, rest.CopyConfig(cached.rc), nil
 }
 
-// restForProviderConfig returns the *rest.config for the given provider config.
-func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kconfig.ProviderConfigSpec) (*rest.Config, error) { // nolint:gocyclo
+// digestWrite feeds client-defining material into the cache-key digest,
+// length-prefixed so adjacent fields cannot alias.
+func digestWrite(d hash.Hash, material ...[]byte) {
+	var length [8]byte
+	for _, m := range material {
+		binary.BigEndian.PutUint64(length[:], uint64(len(m)))
+		d.Write(length[:])
+		d.Write(m)
+	}
+}
+
+// restForProviderConfig returns the *rest.config for the given provider
+// config. Every input that shapes the resulting config (credential source,
+// extracted credential bytes, identity type and credentials) is also written
+// to digest, which callers use as the client cache key.
+func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kconfig.ProviderConfigSpec, digest hash.Hash) (*rest.Config, error) { // nolint:gocyclo
 	var (
 		rc  *rest.Config
 		err error
@@ -111,11 +210,13 @@ func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kco
 		if err != nil {
 			return nil, errors.Wrap(err, errCreateRestConfig)
 		}
+		digestWrite(digest, []byte(cd.Source))
 	default:
 		kc, err := resource.CommonCredentialExtractor(ctx, cd.Source, b.local, cd.CommonCredentialSelectors)
 		if err != nil {
 			return nil, errors.Wrap(err, errGetCreds)
 		}
+		digestWrite(digest, []byte(cd.Source), kc)
 
 		ac, err = clientcmd.Load(kc)
 		if err != nil {
@@ -127,12 +228,26 @@ func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kco
 		}
 	}
 
+	// The client built from this config is shared by every reconcile of the
+	// same credential set, so a per-client token bucket (client-go defaults
+	// to 5 QPS with a burst of 10 when none is set) would serialize them.
+	// Concurrency is bounded by --max-reconcile-rate and the API server's
+	// priority and fairness instead.
+	rc.QPS = -1
+
+	// The token sources the identity wrappers install outlive this call: the
+	// built client is cached and reused by later reconciles, so they must not
+	// inherit the per-reconcile cancellation (crossplane-runtime cancels ctx
+	// once the reconcile returns). Credential reads above stay bound to ctx.
+	wrapCtx := context.WithoutCancel(ctx)
+
 	if id := pc.Identity; id != nil {
+		digestWrite(digest, []byte(id.Type), []byte(id.Source))
 		switch id.Type {
 		case kconfig.IdentityTypeGoogleApplicationCredentials:
 			switch id.Source { //nolint:exhaustive
 			case xpv2.CredentialsSourceInjectedIdentity:
-				if err := gke.WrapRESTConfig(ctx, rc, nil, gke.DefaultScopes...); err != nil {
+				if err := gke.WrapRESTConfig(wrapCtx, rc, nil, gke.DefaultScopes...); err != nil {
 					return nil, errors.Wrap(err, errInjectGoogleCredentials)
 				}
 			default:
@@ -140,8 +255,9 @@ func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kco
 				if err != nil {
 					return nil, errors.Wrap(err, errExtractGoogleCredentials)
 				}
+				digestWrite(digest, creds)
 
-				if err := gke.WrapRESTConfig(ctx, rc, creds, gke.DefaultScopes...); err != nil {
+				if err := gke.WrapRESTConfig(wrapCtx, rc, creds, gke.DefaultScopes...); err != nil {
 					return nil, errors.Wrap(err, errInjectGoogleCredentials)
 				}
 			}
@@ -155,8 +271,9 @@ func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kco
 				if err != nil {
 					return nil, errors.Wrap(err, errExtractAzureCredentials)
 				}
+				digestWrite(digest, creds)
 
-				if err := azure.WrapRESTConfig(ctx, rc, creds, id.Type); err != nil {
+				if err := azure.WrapRESTConfig(wrapCtx, rc, creds, id.Type); err != nil {
 					return nil, errors.Wrap(err, errInjectAzureCredentials)
 				}
 			}
@@ -170,11 +287,12 @@ func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kco
 				if err != nil {
 					return nil, errors.Wrap(err, errExtractUpboundCredentials)
 				}
+				digestWrite(digest, staticToken)
 
 				// We trim the token to remove any leading/trailing whitespace
 				// which may have been added especially when stringData field
 				// is used while creating the secret.
-				if err := upbound.WrapRESTConfig(ctx, rc, strings.TrimSpace(string(staticToken)), b.store); err != nil {
+				if err := upbound.WrapRESTConfig(wrapCtx, rc, strings.TrimSpace(string(staticToken)), b.store); err != nil {
 					return nil, errors.Wrap(err, errInjectUpboundCredentials)
 				}
 			}
@@ -190,10 +308,11 @@ func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kco
 						clusterName = ctxConfig.Cluster
 					}
 				}
+				digestWrite(digest, []byte(clusterName))
 				// AWS Web Identity credentials use the default AWS credentials chain
 				// which includes IRSA (IAM Roles for Service Accounts) via environment variables:
 				// AWS_ROLE_ARN, AWS_WEB_IDENTITY_TOKEN_FILE, AWS_REGION
-				if err := aws.WrapRESTConfig(ctx, rc, clusterName); err != nil {
+				if err := aws.WrapRESTConfig(wrapCtx, rc, clusterName); err != nil {
 					return nil, errors.Wrap(err, errInjectAWSCredentials)
 				}
 			default:
@@ -210,7 +329,8 @@ func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kco
 				if err != nil {
 					return nil, errors.Wrap(err, errExtractNebiusCredentials)
 				}
-				if err := nebius.WrapRESTConfig(ctx, rc, creds, b.nebiusStore); err != nil {
+				digestWrite(digest, creds)
+				if err := nebius.WrapRESTConfig(wrapCtx, rc, creds, b.nebiusStore); err != nil {
 					return nil, errors.Wrap(err, errInjectNebiusCredentials)
 				}
 			}
@@ -267,11 +387,6 @@ func fromAPIConfig(c *api.Config) (*rest.Config, error) {
 		}
 		config.Proxy = http.ProxyURL(proxyURL)
 	}
-
-	// NOTE(tnthornton): these values match the burst and QPS values in kubectl.
-	// xref: https://github.com/kubernetes/kubernetes/pull/105520
-	config.Burst = 300
-	config.QPS = 50
 
 	return config, nil
 }

--- a/pkg/kube/client/client.go
+++ b/pkg/kube/client/client.go
@@ -239,6 +239,8 @@ func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kco
 	// built client is cached and reused by later reconciles, so they must not
 	// inherit the per-reconcile cancellation (crossplane-runtime cancels ctx
 	// once the reconcile returns). Credential reads above stay bound to ctx.
+	// Each wrapper bounds its own token fetches instead, with the request
+	// context or an explicit timeout (see gke.WrapRESTConfig).
 	wrapCtx := context.WithoutCancel(ctx)
 
 	if id := pc.Identity; id != nil {

--- a/pkg/kube/client/client.go
+++ b/pkg/kube/client/client.go
@@ -111,10 +111,10 @@ func WithLogger(l logging.Logger) BuilderOption {
 
 // WithClientCacheSize bounds the number of cached target cluster clients, one
 // per distinct credential set; the least recently used client is evicted
-// beyond the bound. A size of 0 removes the bound.
+// beyond the bound. A size of 0 or less removes the bound.
 func WithClientCacheSize(size int) BuilderOption {
 	return func(b *IdentityAwareBuilder) {
-		b.cacheSize = size
+		b.cacheSize = max(size, 0)
 	}
 }
 

--- a/pkg/kube/client/gke/gke.go
+++ b/pkg/kube/client/gke/gke.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
@@ -31,9 +32,31 @@ var DefaultScopes []string = []string{
 	"https://www.googleapis.com/auth/userinfo.email",
 }
 
+// tokenFetchTimeout bounds every token exchange with Google. The oauth2 token
+// sources keep the context they were built with and perform their HTTP with
+// the *http.Client stored under oauth2.HTTPClient in that context, falling
+// back to http.DefaultClient, which has no timeout. The wrapped REST config is
+// cached and shared by every request of its credential set, and the shared
+// token source serializes those requests on one refresh, so an unbounded
+// exchange would block all of them for as long as the token endpoint stays
+// silent.
+const tokenFetchTimeout = 30 * time.Second
+
+// withTokenFetchClient returns ctx carrying the HTTP client the oauth2 token
+// sources use for their exchanges, unless the caller already supplied one.
+func withTokenFetchClient(ctx context.Context) context.Context {
+	if _, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); ok {
+		return ctx
+	}
+	return context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Timeout: tokenFetchTimeout})
+}
+
 // WrapRESTConfig configures the supplied REST config to use OAuth2 bearer
-// tokens fetched using the supplied Google Application Credentials.
+// tokens fetched using the supplied Google Application Credentials. The token
+// sources it installs outlive the call, so ctx should carry no cancellation;
+// their token exchanges are bounded by tokenFetchTimeout instead.
 func WrapRESTConfig(ctx context.Context, rc *rest.Config, credentials []byte, scopes ...string) error {
+	ctx = withTokenFetchClient(ctx)
 	// TODO(turkenh): Use token.ReuseSourceStore to cache token sources and
 	// avoid token regeneration on every reconciliation loop.
 	var ts oauth2.TokenSource

--- a/pkg/kube/client/gke/gke_test.go
+++ b/pkg/kube/client/gke/gke_test.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2026 The Crossplane Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gke
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/oauth2"
+	"k8s.io/client-go/rest"
+)
+
+// externalAccountCredentials returns workload identity federation credentials
+// that exchange a file-sourced subject token at tokenURL on every refresh,
+// using the context the token source was created with.
+func externalAccountCredentials(t *testing.T, tokenURL string) []byte {
+	t.Helper()
+	subjectTokenFile := filepath.Join(t.TempDir(), "subject-token")
+	if err := os.WriteFile(subjectTokenFile, []byte("subject-token"), 0o600); err != nil {
+		t.Fatalf("WriteFile(...): unexpected error: %v", err)
+	}
+	return fmt.Appendf(nil, `{
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/projects/1/locations/global/workloadIdentityPools/pool/providers/provider",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+  "token_url": %q,
+  "credential_source": {"file": %q}
+}`, tokenURL, subjectTokenFile)
+}
+
+func TestWithTokenFetchClient(t *testing.T) {
+	callerClient := &http.Client{Timeout: time.Second}
+
+	type args struct {
+		ctx context.Context
+	}
+	type want struct {
+		client *http.Client
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"DefaultClientInstalled": {
+			args: args{ctx: context.Background()},
+			want: want{client: &http.Client{Timeout: tokenFetchTimeout}},
+		},
+		"CallerClientKept": {
+			args: args{ctx: context.WithValue(context.Background(), oauth2.HTTPClient, callerClient)},
+			want: want{client: callerClient},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, _ := withTokenFetchClient(tc.args.ctx).Value(oauth2.HTTPClient).(*http.Client)
+			if diff := cmp.Diff(tc.want.client, got); diff != "" {
+				t.Errorf("withTokenFetchClient(...): -want client, +got client:\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestWrapRESTConfigTokenFetch exercises the token exchange behind the wrapped
+// transport against an httptest token endpoint: the exchanged token must
+// authenticate requests, and a token endpoint that never answers must fail
+// the request within the timeout of the HTTP client carried by the context
+// instead of blocking it for good.
+func TestWrapRESTConfigTokenFetch(t *testing.T) {
+	type result struct {
+		Authorization string
+		// TimedOut reports whether the token exchange ended by the HTTP
+		// client's timeout. The oauth2 library wraps that error without %w,
+		// so it is recognized by net/http's message rather than by type.
+		TimedOut bool
+	}
+	type args struct {
+		// tokenTimeout replaces the wrapper's default timeout when set, so
+		// the silent endpoint case does not have to wait for it.
+		tokenTimeout time.Duration
+		tokenServer  http.HandlerFunc
+	}
+	type want struct {
+		result result
+		err    bool
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"ExchangedTokenAuthenticatesRequest": {
+			args: args{
+				tokenServer: func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"access_token":"sts-token","token_type":"Bearer","expires_in":3600}`))
+				},
+			},
+			want: want{result: result{Authorization: "Bearer sts-token"}},
+		},
+		"SilentTokenEndpointFailsWithinTimeout": {
+			args: args{
+				tokenTimeout: 200 * time.Millisecond,
+				tokenServer: func(_ http.ResponseWriter, r *http.Request) {
+					// The server only notices the client giving up once the
+					// request body has been consumed.
+					_, _ = io.Copy(io.Discard, r.Body)
+					<-r.Context().Done()
+				},
+			},
+			want: want{result: result{TimedOut: true}, err: true},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			tokenServer := httptest.NewServer(tc.args.tokenServer)
+			defer tokenServer.Close()
+
+			var authorization atomic.Pointer[string]
+			apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				h := r.Header.Get("Authorization")
+				authorization.Store(&h)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			defer apiServer.Close()
+
+			ctx := context.Background()
+			if tc.args.tokenTimeout > 0 {
+				ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Timeout: tc.args.tokenTimeout})
+			}
+			rc := &rest.Config{Host: apiServer.URL}
+			if err := WrapRESTConfig(ctx, rc, externalAccountCredentials(t, tokenServer.URL), DefaultScopes...); err != nil {
+				t.Fatalf("WrapRESTConfig(...): unexpected error: %v", err)
+			}
+			hc, err := rest.HTTPClientFor(rc)
+			if err != nil {
+				t.Fatalf("rest.HTTPClientFor(...): unexpected error: %v", err)
+			}
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, apiServer.URL+"/version", nil)
+			if err != nil {
+				t.Fatalf("http.NewRequestWithContext(...): unexpected error: %v", err)
+			}
+
+			resp, err := hc.Do(req)
+			if resp != nil {
+				_ = resp.Body.Close()
+			}
+
+			got := result{}
+			if h := authorization.Load(); h != nil {
+				got.Authorization = *h
+			}
+			got.TimedOut = err != nil && strings.Contains(err.Error(), "Client.Timeout exceeded")
+			if diff := cmp.Diff(tc.want.err, err != nil); diff != "" {
+				t.Errorf("request through the wrapped REST config: -want error, +got error: %v\n%s", err, diff)
+			}
+			if diff := cmp.Diff(tc.want.result, got); diff != "" {
+				t.Errorf("request through the wrapped REST config (error: %v): -want, +got:\n%s", err, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

Fixes #541

**Summary:** every reconcile built a fresh controller-runtime client for the target cluster, and since controller-runtime `v0.20.0` a fresh client's `RESTMapper` primes itself with *full aggregated discovery* (`GET /api` + `GET /apis`, every CRD in the cluster) on its first lookup. On CRD-heavy clusters that is a multi-megabyte decode per reconcile, which is the ~3x memory / ~5x CPU regression under `watch` load described in #541 (root cause, upstream references and the original measurements live there). This PR caches the built client per credential set so discovery is primed once per credential set instead of once per reconcile.

Two commits, reviewable separately:

1. `fix(aws): issue EKS tokens with the request context` - `eksTokenSource` stored the context of the reconcile that built the REST config and presigned every later `GetCallerIdentity` with it ([`aws.go:125`](https://github.com/jonasz-lasut/provider-kubernetes/blob/c56b5e3/pkg/kube/client/aws/aws.go#L125), [`:161`](https://github.com/jonasz-lasut/provider-kubernetes/blob/c56b5e3/pkg/kube/client/aws/aws.go#L161)). crossplane-runtime cancels that context when the reconcile returns, so anything that outlives the reconcile (today the `watch` informers, with this PR the cached client) refreshed IRSA credentials against a dead context. The token source now takes `req.Context()`. Standalone fix, safe on its own.
2. `fix: cache per-ProviderConfig clients to avoid discovery per reconcile` - the cache itself.

#### What the cache does

- `IdentityAwareBuilder` keeps an LRU (`k8s.io/utils/lru`, already a dependency) of built clients keyed by a SHA-256 digest of everything that shapes the `rest.Config`: credential source and kubeconfig bytes, identity type/source and identity credential bytes, and the AWS cluster name ([`client.go:150-183`](https://github.com/jonasz-lasut/provider-kubernetes/blob/c56b5e3/pkg/kube/client/client.go#L150-L183), fields length-prefixed at [`:187`](https://github.com/jonasz-lasut/provider-kubernetes/blob/c56b5e3/pkg/kube/client/client.go#L187)). A changed credential is a new key and a new client; a rotating token behind the same credential keeps the live client, because every identity wrapper installs a self-refreshing token source behind `rc.Wrap`. `singleflight` collapses concurrent cold-cache builds of the same client.
- One builder is shared by the four controllers (cluster/namespaced x Object/ObservedObjectCollection) through `internal/controller.Options.ClientBuilder`, so the cache is shared too. Its bound is `--client-cache-size` (default `8`: one entry per distinct credential set, and most control planes manage the in-cluster API plus one or two clusters; `0` removes the bound, values above `math.MaxInt` are rejected at startup, and the builder treats a negative size as `0`). `Setup` and `SetupGated` fail without a builder instead of panicking on the first reconcile. Build and eviction are logged at debug level, never the key.
- The identity wrappers are built with `context.WithoutCancel(ctx)` ([`client.go:242`](https://github.com/jonasz-lasut/provider-kubernetes/blob/c56b5e3/pkg/kube/client/client.go#L242)) while Secret reads stay bound to the reconcile context. Without this, the Google `external_account`/`authorized_user` token sources (which store the context they were created with and do HTTP with it) would fail with `context canceled` permanently after their first access-token expiry once the client is cached; `TestKubeForProviderConfigOutlivesContext` reproduces exactly that against an httptest STS and fails if the detachment is removed.
- `rc.QPS = -1` for target clusters ([`client.go:236`](https://github.com/jonasz-lasut/provider-kubernetes/blob/c56b5e3/pkg/kube/client/client.go#L236)). **Behavior change, please look at this one:** a cached client is shared by every concurrent reconcile of its credential set, so client-go's per-client token bucket (`5 QPS / burst 10`, the default whenever a config sets none, which is the case for both the in-cluster and the kubeconfig path here) would have serialized them, where it previously applied per reconcile and never bit. Disabling client-side throttling keeps the effective pre-PR behavior for reconciles, but it applies to everything built from the returned config: the reconcile client, the watch informers and the server-side apply discovery client are all unthrottled on the client side now. `--max-reconcile-rate` and the target cluster's API Priority and Fairness bound the load instead; the README documents this. The returned `*rest.Config` is a copy so callers cannot mutate the cached one.
- `token.ReuseSourceStore` (Upbound) and `nebius.SDKStore` stay: they cache a different layer (the token source / SDK, keyed by identity credential only) and are still needed because the wrappers run before the cache lookup and two clusters sharing an identity share one token source.

**Confirmed (code, controller-runtime `v0.23.1`):** `apiutil` mapper holds a `discovery.AggregatedDiscoveryInterface` and primes all groups on the first lookup; `client.New`, `cache.New` and `discovery.NewDiscoveryClientForConfig` each `rest.CopyConfig` first and all per-call options (field owner, dry-run, force) are per request, so sharing one client across reconcilers is safe.

#### Benchmark

**Tested (kind `v1.36.1`, single node, Docker via colima on Apple Silicon macOS; Crossplane `v2.3.4`; provider built and deployed with `make local-deploy`, `--debug`, watches off, default `--max-reconcile-rate=100`; `main` vs this branch):** 1000 ballast CRDs (100 groups x 10 kinds), 300 `Object`s each managing a `ConfigMap` through `ClusterProviderConfig/kubernetes-provider` (`InjectedIdentity`), settle + 3 update rounds, provider sampled every 2 s with a 30 s cooldown per phase. Discovery requests are `apiserver_request_total{subresource="api"|"apis"}` from the API server; heap/RSS from the provider's `/metrics`; working set from the kubelet stats summary.

| phase | build | duration | discovery req | apiserver req | provider req | peak heap in use MiB | peak heap sys MiB | peak RSS MiB | peak working set MiB |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|
| settle | main | 6.26 s | 1278 | 7560 | 5619 | 834 | 954 | 1003 | 966 |
| round-1 | main | 2.31 s | 604 | 3180 | 2700 | 665 | 954 | 844 | 806 |
| round-2 | main | 2.25 s | 604 | 3181 | 2700 | 694 | 953 | 979 | 942 |
| round-3 | main | 2.48 s | 604 | 3182 | 2700 | 695 | 985 | 979 | 942 |
| settle | cache | 4.31 s | 6 | 5622 | 4392 | 106 | 124 | 161 | 102 |
| round-1 | cache | 2.41 s | 4 | 3136 | 2101 | 94 | 122 | 159 | 114 |
| round-2 | cache | 2.32 s | 4 | 3008 | 2101 | 92 | 133 | 171 | 131 |
| round-3 | cache | 2.45 s | 4 | 2584 | 2101 | 94 | 134 | 171 | 131 |

Steady state, average of rounds 1-3:

| metric | main | cache | change |
|---|---:|---:|---:|
| duration | 2.35 s | 2.39 s | ~same |
| discovery requests / round | 604 | 4 | -99.3% |
| apiserver requests / round | 3181 | 2909 | -9% |
| provider requests / round | 2700 | 2101 | -22% |
| peak heap in use | 685 MiB | 93 MiB | -86% |
| peak heap sys | 964 MiB | 130 MiB | -87% |
| peak RSS | 934 MiB | 167 MiB | -82% |
| peak working set | 897 MiB | 125 MiB | -86% |

`main` issues two discovery requests per `Object` per round (one per client build); the branch issues a constant 4. Round latency is unchanged at this scale: the regression is memory and CPU, not throughput.

#### Not in this PR

- No cache hit/miss metrics
- provider-helm imports this builder and inherits the fix on its next dependency bump; its own Helm SDK discovery path is separate.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- Unit tests (`make reviewable test` green, `go test -race ./pkg/kube/client/...` green):
  - `TestKubeForProviderConfigCaching` - same credentials reuse the client, different kubeconfig or different identity credentials build a new one, LRU eviction with a bound of 1, a negative bound caches without limit (the LRU would otherwise evict every entry on insert).
  - `TestKubeForProviderConfigConcurrentBuildsCollapse` - 16 concurrent cold-cache callers share one client and trigger one build.
  - `TestKubeForProviderConfigOutlivesContext` - hermetic Google `external_account` flow against an httptest STS and API server; the build context is cancelled and a request through the cached REST config still carries the exchanged bearer token. Fails with `Post ...: context canceled` without the `WithoutCancel`.
  - `TestKubeForProviderConfigRESTConfig` - `QPS == -1`, returned config is a copy.
  - `TestDigestWrite` - field boundaries and embedded delimiters do not alias.
  - `TestBearerAuthRoundTripper` - the EKS token source is called with the request context and the token lands in `Authorization`.
- Benchmarked on kind as described above against `main` and this branch with a Go reconcile load test (to be proposed separately); raw output available on request.
- Identity wrapper behavior under caching was confirmed at source for `gke`, `azure`, `upbound`, `aws` and `nebius` (self-refreshing token sources behind the cached transports, context handling per wrapper); the kubeconfig and in-cluster paths were exercised live, the cloud identity paths were not.

[contribution process]: https://git.io/fj2m9

