### PR TITLE
Fix ObservedObjectCollection failing to create Objects due to incorrectly serialized deletionPropagationPolicy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ CROSSPLANE_NAMESPACE = crossplane-system
 -include build/makelib/local.xpkg.mk
 -include build/makelib/controlplane.mk
 
-UPTEST_EXAMPLE_LIST ?= "examples/namespaced/object/object.yaml,examples/namespaced/object/object-watching.yaml,examples/namespaced/object/object-ssa-owner.yaml,examples/namespaced/object/object-csa-migration.yaml,examples/namespaced/object/object-wrapped-provider-config.yaml"
+UPTEST_EXAMPLE_LIST ?= "examples/namespaced/object/object.yaml,examples/namespaced/object/object-watching.yaml,examples/namespaced/object/object-ssa-owner.yaml,examples/namespaced/object/object-csa-migration.yaml,examples/namespaced/object/object-wrapped-provider-config.yaml,examples/namespaced/collection/collection.yaml"
 uptest: $(UPTEST) $(KUBECTL) $(CHAINSAW) $(CROSSPLANE_CLI)
 	@$(INFO) running automated tests
 	@KUBECTL=$(KUBECTL) CHAINSAW=$(CHAINSAW) CROSSPLANE_CLI=$(CROSSPLANE_CLI) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) $(UPTEST) e2e "$(UPTEST_EXAMPLE_LIST)" --setup-script=cluster/test/setup.sh || $(FAIL)

--- a/apis/cluster/object/v1alpha2/types.go
+++ b/apis/cluster/object/v1alpha2/types.go
@@ -85,7 +85,7 @@ type ObjectParameters struct {
 	// +optional
 	// +kubebuilder:validation:Enum=Orphan;Background;Foreground
 	// +kubebuilder:default=Background
-	DeletionPropagationPolicy metav1.DeletionPropagation `json:"deletionPropagationPolicy"`
+	DeletionPropagationPolicy metav1.DeletionPropagation `json:"deletionPropagationPolicy,omitempty"`
 }
 
 // ObjectObservation are the observable fields of a Object.

--- a/apis/namespaced/object/v1alpha1/types.go
+++ b/apis/namespaced/object/v1alpha1/types.go
@@ -85,7 +85,7 @@ type ObjectParameters struct {
 	// +optional
 	// +kubebuilder:validation:Enum=Orphan;Background;Foreground
 	// +kubebuilder:default=Background
-	DeletionPropagationPolicy metav1.DeletionPropagation `json:"deletionPropagationPolicy"`
+	DeletionPropagationPolicy metav1.DeletionPropagation `json:"deletionPropagationPolicy,omitempty"`
 }
 
 // ObjectObservation are the observable fields of a Object.

--- a/examples/cluster/collection/collection.yaml
+++ b/examples/cluster/collection/collection.yaml
@@ -1,24 +1,28 @@
 ---
 apiVersion: v1
-kind: ConfigMap
+kind: Pod
 metadata:
-  name: configmap-bar
-  namespace: default
   labels:
     foo: bar
-data:
-  sample-key: "sample-value"
+  name: pod-bar
+  namespace: crossplane-system
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: pod-bar
 
 ---
 apiVersion: v1
-kind: ConfigMap
+kind: Pod
 metadata:
-  name: configmap-foo
-  namespace: default
   labels:
     foo: bar
-data:
-  sample-key: "sample-value2"
+  name: pod-foo
+  namespace: crossplane-system
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: pod-foo
 ---
 apiVersion: kubernetes.crossplane.io/v1alpha1
 kind: ObservedObjectCollection
@@ -27,7 +31,7 @@ metadata:
 spec:
   observeObjects:
     apiVersion: v1
-    kind: ConfigMap
+    kind: Pod
     selector:
       matchLabels:
         foo: bar
@@ -39,4 +43,3 @@ spec:
         a1: v1
   providerConfigRef:
     name: kubernetes-provider
-

--- a/examples/namespaced/collection/collection.yaml
+++ b/examples/namespaced/collection/collection.yaml
@@ -1,24 +1,29 @@
 ---
 apiVersion: v1
-kind: ConfigMap
+kind: Pod
 metadata:
-  name: configmap-bar
-  namespace: other-ns
   labels:
     foo: bar
-data:
-  sample-key: "sample-value"
+  name: pod-bar
+  namespace: crossplane-system
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: pod-bar
 
 ---
 apiVersion: v1
-kind: ConfigMap
+kind: Pod
 metadata:
-  name: configmap-foo
-  namespace: default
   labels:
     foo: bar
-data:
-  sample-key: "sample-value2"
+  name: pod-foo
+  namespace: crossplane-system
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: pod-foo
+
 ---
 apiVersion: kubernetes.m.crossplane.io/v1alpha1
 kind: ObservedObjectCollection
@@ -28,7 +33,7 @@ metadata:
 spec:
   observeObjects:
     apiVersion: v1
-    kind: ConfigMap
+    kind: Pod
     selector:
       matchLabels:
         foo: bar
@@ -41,4 +46,3 @@ spec:
   providerConfigRef:
     kind: ClusterProviderConfig
     name: kubernetes-provider
-

--- a/internal/controller/cluster/observedobjectcollection/reconciler_test.go
+++ b/internal/controller/cluster/observedobjectcollection/reconciler_test.go
@@ -149,6 +149,11 @@ func TestReconciler(t *testing.T) {
 						if s := sets.New[string]("col-foo0", "col-foo1"); !s.Has(u.GetName()) {
 							return fmt.Errorf("Expecting one of %v, but got %v", s.UnsortedList(), u.GetName())
 						}
+						// Regression test for https://github.com/crossplane-contrib/provider-kubernetes/issues/555:
+						// deletionPropagationPolicy should not be set by ObservedObjectCollection
+						if p, found, _ := unstructured.NestedString(u.Object, "spec", "forProvider", "deletionPropagationPolicy"); found {
+							return fmt.Errorf("Expected deletionPropagationPolicy to be nil, but got: %q", p)
+						}
 						manifest, found, err := unstructured.NestedMap(u.Object, "spec", "forProvider", "manifest")
 						if err != nil {
 							return err
@@ -249,6 +254,11 @@ func TestReconciler(t *testing.T) {
 						}
 						if s := sets.New[string]("col-foo0", "col-foo1"); !s.Has(u.GetName()) {
 							return fmt.Errorf("Expecting one of %v, but got %v", s.UnsortedList(), u.GetName())
+						}
+						// Regression test for https://github.com/crossplane-contrib/provider-kubernetes/issues/555:
+						// deletionPropagationPolicy should not be set by ObservedObjectCollection
+						if p, found, _ := unstructured.NestedString(u.Object, "spec", "forProvider", "deletionPropagationPolicy"); found {
+							return fmt.Errorf("Expected deletionPropagationPolicy to be nil, but got: %q", p)
 						}
 						manifest, found, err := unstructured.NestedMap(u.Object, "spec", "forProvider", "manifest")
 						if err != nil {

--- a/internal/controller/namespaced/observedobjectcollection/reconciler_test.go
+++ b/internal/controller/namespaced/observedobjectcollection/reconciler_test.go
@@ -154,6 +154,11 @@ func TestReconciler(t *testing.T) {
 						if s := sets.New[string]("col-foo0", "col-foo1"); !s.Has(u.GetName()) {
 							return fmt.Errorf("Expecting one of %v, but got %v", s.UnsortedList(), u.GetName())
 						}
+						// Regression test for https://github.com/crossplane-contrib/provider-kubernetes/issues/555:
+						// deletionPropagationPolicy should not be set by ObservedObjectCollection
+						if p, found, _ := unstructured.NestedString(u.Object, "spec", "forProvider", "deletionPropagationPolicy"); found {
+							return fmt.Errorf("Expected deletionPropagationPolicy to be nil, but got: %q", p)
+						}
 						manifest, found, err := unstructured.NestedMap(u.Object, "spec", "forProvider", "manifest")
 						if err != nil {
 							return err
@@ -258,6 +263,11 @@ func TestReconciler(t *testing.T) {
 						}
 						if s := sets.New[string]("col-foo0", "col-foo1"); !s.Has(u.GetName()) {
 							return fmt.Errorf("Expecting one of %v, but got %v", s.UnsortedList(), u.GetName())
+						}
+						// Regression test for https://github.com/crossplane-contrib/provider-kubernetes/issues/555:
+						// deletionPropagationPolicy should not be set by ObservedObjectCollection
+						if p, found, _ := unstructured.NestedString(u.Object, "spec", "forProvider", "deletionPropagationPolicy"); found {
+							return fmt.Errorf("Expected deletionPropagationPolicy to be nil, but got: %q", p)
 						}
 						manifest, found, err := unstructured.NestedMap(u.Object, "spec", "forProvider", "manifest")
 						if err != nil {


### PR DESCRIPTION
### Description of your changes

Fixes #555
* adds omitempty to deletionPropagationPolicy so that it does not get serialized to empty string `""`
* adds unit tests to cover regression
* updates the `ObservedObjectCollection` example to be uptestable -configmaps did not have status.conditions, which resulted in e2e tests always failing. Updated `ObservedObjectCollection` to observe Deployments in crossplane-system namespace, which always exists in e2e tests and contains crossplane & crossplane-rbac-manager deployments.
* adds e2e target for `ObservedObjectCollection`

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Added E2E target to test ObservedObjectCollection, added unit tests

[contribution process]: https://git.io/fj2m9
