### PR TITLE
Add a client cache autopilot as a replacement for user-provided flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,12 @@ headroom for credentials that rotate, never below 8. The result is logged at
 startup. The provider does not start if its ProviderConfigs cannot be listed.
 
 The bound is fixed for the lifetime of the process, so ProviderConfigs created
-after startup share the headroom until the next restart.
+after startup share the headroom until the next restart. The cache reports
+`provider_kubernetes_client_cache_size` (the bound),
+`provider_kubernetes_client_cache_entries` (clients currently cached) and
+`provider_kubernetes_client_cache_events_total` with an `event` label of
+`hit`, `miss` or `evict`; a sustained eviction rate means the credential sets
+in use no longer fit the bound.
 
 Client-side rate limiting is disabled for these clients. A cached client is
 shared by every concurrent reconcile of its credential set, so client-go's

--- a/README.md
+++ b/README.md
@@ -31,11 +31,22 @@ spec:
 ## Target cluster clients
 
 The provider builds one client per distinct ProviderConfig credential set
-(kubeconfig plus identity) and keeps it in an LRU cache bounded by
-`--client-cache-size` (default 8, `0` removes the bound). Building a client is
+(kubeconfig plus identity) and keeps it in an LRU cache. Building a client is
 expensive because its REST mapper primes itself with full aggregated discovery
-on first use, so size the cache to the number of distinct credential sets the
-provider talks to.
+on first use, so the cache has to hold every credential set the provider talks
+to: a credential set that does not fit is rebuilt, discovery included, on every
+reconcile.
+
+At startup the provider sizes the cache from the cluster: it lists its
+`ProviderConfig` and `ClusterProviderConfig` objects, derives the cache key of
+each one the way the client builder does (so ProviderConfigs sharing a
+kubeconfig count once, and every in-cluster ProviderConfig counts as one), and
+bounds the cache at the number of distinct credential sets plus ten percent of
+headroom for credentials that rotate, never below 8. The result is logged at
+startup. The provider does not start if its ProviderConfigs cannot be listed.
+
+The bound is fixed for the lifetime of the process, so ProviderConfigs created
+after startup share the headroom until the next restart.
 
 Client-side rate limiting is disabled for these clients. A cached client is
 shared by every concurrent reconcile of its credential set, so client-go's

--- a/README.md
+++ b/README.md
@@ -34,17 +34,23 @@ The provider builds one client per distinct ProviderConfig credential set
 (kubeconfig plus identity) and keeps it in an LRU cache. Building a client is
 expensive because its REST mapper primes itself with full aggregated discovery
 on first use, so the cache has to hold every credential set the provider talks
-to: a credential set that does not fit is rebuilt, discovery included, on every
-reconcile.
+to. Once the credential sets in use outnumber the bound, every new client
+evicts the least recently used one, whose next reconcile rebuilds it (discovery
+included) and evicts another: the whole cache churns, not only the credential
+set that did not fit.
 
 At startup the provider sizes the cache from the cluster: it lists its
 `ProviderConfig` and `ClusterProviderConfig` objects, derives the cache key of
 each one the way the client builder does (so ProviderConfigs sharing a
 kubeconfig count once, and every in-cluster ProviderConfig counts as one), and
-bounds the cache at the number of distinct credential sets plus ten percent of
-headroom for credentials that rotate, never below 8. The result is logged at
+bounds the cache at the number of distinct credential sets plus headroom of
+ten percent or four entries, whichever is larger, for credentials that rotate
+and ProviderConfigs created later, never below 8. The result is logged at
 startup. The provider does not start if its ProviderConfigs and their
-credentials cannot be read within 300 seconds.
+credentials cannot be read within 300 seconds. When the provider runs outside a
+cluster, as in local development, ProviderConfigs with an in-cluster identity
+cannot be resolved and each counts as a credential set of its own, so the
+cache is merely oversized.
 
 The bound is fixed for the lifetime of the process, so ProviderConfigs created
 after startup share the headroom until the next restart. The cache reports
@@ -52,7 +58,7 @@ after startup share the headroom until the next restart. The cache reports
 `provider_kubernetes_client_cache_entries` (clients currently cached) and
 `provider_kubernetes_client_cache_events_total` with an `event` label of
 `hit`, `miss` or `evict`; a sustained eviction rate means the credential sets
-in use no longer fit the bound.
+in use no longer fit the bound and the cache is churning.
 
 Client-side rate limiting is disabled for these clients. A cached client is
 shared by every concurrent reconcile of its credential set, so client-go's

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ each one the way the client builder does (so ProviderConfigs sharing a
 kubeconfig count once, and every in-cluster ProviderConfig counts as one), and
 bounds the cache at the number of distinct credential sets plus ten percent of
 headroom for credentials that rotate, never below 8. The result is logged at
-startup. The provider does not start if its ProviderConfigs cannot be listed.
+startup. The provider does not start if its ProviderConfigs and their
+credentials cannot be read within 300 seconds.
 
 The bound is fixed for the lifetime of the process, so ProviderConfigs created
 after startup share the headroom until the next restart. The cache reports

--- a/cmd/provider/cachesize.go
+++ b/cmd/provider/cachesize.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+
+	clusterv1alpha1 "github.com/crossplane-contrib/provider-kubernetes/apis/cluster/v1alpha1"
+	namespacedv1alpha1 "github.com/crossplane-contrib/provider-kubernetes/apis/namespaced/v1alpha1"
+	kubeclient "github.com/crossplane-contrib/provider-kubernetes/pkg/kube/client"
+	kconfig "github.com/crossplane-contrib/provider-kubernetes/pkg/kube/config"
+)
+
+// clientCacheSizeTimeout bounds the startup listing that sizes the target
+// cluster client cache.
+const clientCacheSizeTimeout = 30 * time.Second
+
+// clientCacheSize returns the bound of the target cluster client cache,
+// derived from the ProviderConfigs kube lists and the credentials they
+// reference. The bound is fixed for the lifetime of the process, so
+// ProviderConfigs created later share whatever headroom is left.
+func clientCacheSize(ctx context.Context, log logging.Logger, kube client.Client) (int, error) {
+	pcs, err := providerConfigSpecs(ctx, kube)
+	if err != nil {
+		return 0, errors.Wrap(err, "cannot size target cluster client cache from ProviderConfigs")
+	}
+
+	sizing, err := kubeclient.ClientCacheSizeFor(ctx, kube, pcs)
+	if err != nil {
+		return 0, errors.Wrap(err, "cannot size the client cache")
+	}
+
+	log.Info("Sized target cluster client cache from ProviderConfigs",
+		"providerConfigs", len(pcs),
+		"credentialSets", sizing.CredentialSets,
+		"unresolved", sizing.Unresolved,
+		"clientCacheSize", sizing.Size)
+	return sizing.Size, nil
+}
+
+// providerConfigSpecs returns the spec of every ProviderConfig the provider
+// serves: the legacy cluster-scoped kind and the namespaced and cluster-scoped
+// kinds of the namespaced API group. A kind whose CRD is not installed
+// contributes none.
+func providerConfigSpecs(ctx context.Context, kube client.Reader) ([]kconfig.ProviderConfigSpec, error) {
+	var pcs []kconfig.ProviderConfigSpec
+
+	legacy := &clusterv1alpha1.ProviderConfigList{}
+	if err := kube.List(ctx, legacy); err != nil && !meta.IsNoMatchError(err) {
+		return nil, errors.Wrapf(err, "cannot list %s", clusterv1alpha1.ProviderConfigGroupKind)
+	}
+	for i := range legacy.Items {
+		pcs = append(pcs, legacy.Items[i].Spec)
+	}
+
+	namespaced := &namespacedv1alpha1.ProviderConfigList{}
+	if err := kube.List(ctx, namespaced); err != nil && !meta.IsNoMatchError(err) {
+		return nil, errors.Wrapf(err, "cannot list %s", namespacedv1alpha1.ProviderConfigGroupKind)
+	}
+	for i := range namespaced.Items {
+		pcs = append(pcs, namespaced.Items[i].Spec)
+	}
+
+	cluster := &namespacedv1alpha1.ClusterProviderConfigList{}
+	if err := kube.List(ctx, cluster); err != nil && !meta.IsNoMatchError(err) {
+		return nil, errors.Wrapf(err, "cannot list %s", namespacedv1alpha1.ClusterProviderConfigGroupKind)
+	}
+	for i := range cluster.Items {
+		pcs = append(pcs, cluster.Items[i].Spec)
+	}
+
+	return pcs, nil
+}

--- a/cmd/provider/cachesize.go
+++ b/cmd/provider/cachesize.go
@@ -32,9 +32,10 @@ import (
 	kconfig "github.com/crossplane-contrib/provider-kubernetes/pkg/kube/config"
 )
 
-// clientCacheSizeTimeout bounds the startup listing that sizes the target
-// cluster client cache.
-const clientCacheSizeTimeout = 30 * time.Second
+// clientCacheSizeTimeout bounds the startup listing and credential reads that
+// size the target cluster client cache; the provider does not start without a
+// size, since a partial count would not be a bound.
+const clientCacheSizeTimeout = 300 * time.Second
 
 // clientCacheSize returns the bound of the target cluster client cache,
 // derived from the ProviderConfigs kube lists and the credentials they

--- a/cmd/provider/cachesize_test.go
+++ b/cmd/provider/cachesize_test.go
@@ -198,7 +198,7 @@ func TestClientCacheSize(t *testing.T) {
 		},
 		"ManyCredentialSetsGetHeadroom": {
 			args: args{kube: &test.MockClient{MockList: manyProviderConfigs(20), MockGet: getSecrets(manySecrets)}},
-			want: want{size: 22},
+			want: want{size: 24},
 		},
 	}
 

--- a/cmd/provider/cachesize_test.go
+++ b/cmd/provider/cachesize_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
+
+	clusterv1alpha1 "github.com/crossplane-contrib/provider-kubernetes/apis/cluster/v1alpha1"
+	namespacedv1alpha1 "github.com/crossplane-contrib/provider-kubernetes/apis/namespaced/v1alpha1"
+	kubeclient "github.com/crossplane-contrib/provider-kubernetes/pkg/kube/client"
+	kconfig "github.com/crossplane-contrib/provider-kubernetes/pkg/kube/config"
+)
+
+var errBoom = errors.New("boom")
+
+// specFor references the kubeconfig key of the named Secret.
+func specFor(secret string) kconfig.ProviderConfigSpec {
+	return kconfig.ProviderConfigSpec{
+		Credentials: kconfig.ProviderCredentials{
+			Source: xpv2.CredentialsSourceSecret,
+			CommonCredentialSelectors: xpv2.CommonCredentialSelectors{
+				SecretRef: &xpv2.SecretKeySelector{
+					SecretReference: xpv2.SecretReference{Name: secret, Namespace: "crossplane-system"},
+					Key:             "kubeconfig",
+				},
+			},
+		},
+	}
+}
+
+func kubeconfigFor(server string) []byte {
+	return fmt.Appendf(nil, `apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    server: %s
+contexts:
+- name: ctx
+  context:
+    cluster: c
+    user: u
+current-context: ctx
+users:
+- name: u
+  user: {}
+`, server)
+}
+
+// listProviderConfigs serves one ProviderConfig of every kind, referencing
+// the named Secrets in order.
+func listProviderConfigs(legacy, namespaced, cluster string) test.MockListFn {
+	return func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+		switch l := list.(type) {
+		case *clusterv1alpha1.ProviderConfigList:
+			l.Items = []clusterv1alpha1.ProviderConfig{{Spec: specFor(legacy)}}
+		case *namespacedv1alpha1.ProviderConfigList:
+			l.Items = []namespacedv1alpha1.ProviderConfig{{Spec: specFor(namespaced)}}
+		case *namespacedv1alpha1.ClusterProviderConfigList:
+			l.Items = []namespacedv1alpha1.ClusterProviderConfig{{Spec: specFor(cluster)}}
+		default:
+			return fmt.Errorf("unexpected list type %T", list)
+		}
+		return nil
+	}
+}
+
+// getSecrets serves the kubeconfig key of the named Secrets.
+func getSecrets(secrets map[string][]byte) test.MockGetFn {
+	return func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+		kc, ok := secrets[key.Name]
+		if !ok {
+			return errBoom
+		}
+		obj.(*corev1.Secret).Data = map[string][]byte{"kubeconfig": kc}
+		return nil
+	}
+}
+
+func TestProviderConfigSpecs(t *testing.T) {
+	noMatch := &meta.NoKindMatchError{GroupKind: namespacedv1alpha1.ClusterProviderConfigGroupVersionKind.GroupKind()}
+
+	type args struct {
+		list test.MockListFn
+	}
+	type want struct {
+		specs []kconfig.ProviderConfigSpec
+		err   error
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"EveryKindContributes": {
+			args: args{list: listProviderConfigs("legacy", "namespaced", "cluster")},
+			want: want{specs: []kconfig.ProviderConfigSpec{specFor("legacy"), specFor("namespaced"), specFor("cluster")}},
+		},
+		"KindWithoutCRDContributesNone": {
+			args: args{list: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*namespacedv1alpha1.ClusterProviderConfigList); ok {
+					return noMatch
+				}
+				return listProviderConfigs("legacy", "namespaced", "")(ctx, list, opts...)
+			}},
+			want: want{specs: []kconfig.ProviderConfigSpec{specFor("legacy"), specFor("namespaced")}},
+		},
+		"ListErrorIsReturned": {
+			args: args{list: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+				if _, ok := list.(*namespacedv1alpha1.ProviderConfigList); ok {
+					return errBoom
+				}
+				return nil
+			}},
+			want: want{err: errors.Wrapf(errBoom, "cannot list %s", namespacedv1alpha1.ProviderConfigGroupKind)},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := providerConfigSpecs(context.Background(), &test.MockClient{MockList: tc.args.list})
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Fatalf("providerConfigSpecs(...): -want error, +got error:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.specs, got); diff != "" {
+				t.Errorf("providerConfigSpecs(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestClientCacheSize(t *testing.T) {
+	kubeconfigA := kubeconfigFor("https://a.example.org:6443")
+	sharedSecrets := map[string][]byte{
+		"a":      kubeconfigA,
+		"a-copy": kubeconfigA,
+		"b":      kubeconfigFor("https://b.example.org:6443"),
+	}
+	// manyProviderConfigs serves n legacy ProviderConfigs with a kubeconfig
+	// each, so that the sizing rises above the default.
+	manySecrets := map[string][]byte{}
+	manyProviderConfigs := func(n int) test.MockListFn {
+		return func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+			if l, ok := list.(*clusterv1alpha1.ProviderConfigList); ok {
+				for i := range n {
+					name := fmt.Sprintf("kubeconfig-%d", i)
+					manySecrets[name] = kubeconfigFor(fmt.Sprintf("https://%d.example.org:6443", i))
+					l.Items = append(l.Items, clusterv1alpha1.ProviderConfig{Spec: specFor(name)})
+				}
+			}
+			return nil
+		}
+	}
+
+	type args struct {
+		kube client.Client
+	}
+	type want struct {
+		size int
+		err  bool
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"ListFailureIsAnError": {
+			args: args{kube: &test.MockClient{MockList: test.NewMockListFn(errBoom), MockGet: getSecrets(sharedSecrets)}},
+			want: want{err: true},
+		},
+		"SharedCredentialsStayWithinTheDefault": {
+			args: args{kube: &test.MockClient{MockList: listProviderConfigs("a", "a-copy", "b"), MockGet: getSecrets(sharedSecrets)}},
+			want: want{size: kubeclient.DefaultClientCacheSize},
+		},
+		"ManyCredentialSetsGetHeadroom": {
+			args: args{kube: &test.MockClient{MockList: manyProviderConfigs(20), MockGet: getSecrets(manySecrets)}},
+			want: want{size: 22},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := clientCacheSize(context.Background(), logging.NewNopLogger(), tc.args.kube)
+			if diff := cmp.Diff(tc.want.err, err != nil); diff != "" {
+				t.Fatalf("clientCacheSize(...): -want error, +got error (%v):\n%s", err, diff)
+			}
+			if diff := cmp.Diff(tc.want.size, got); diff != "" {
+				t.Errorf("clientCacheSize(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -21,10 +21,8 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math"
 	"os"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -97,7 +95,6 @@ func main() {
 		pollJitterPercentage    = app.Flag("poll-jitter-percentage", "Percentage of jitter to apply to poll interval. It cannot be negative, and must be less than 100.").Default("10").Uint()
 		leaderElection          = app.Flag("leader-election", "Use leader election for the controller manager.").Short('l').Default("false").Envar("LEADER_ELECTION").Bool()
 		maxReconcileRate        = app.Flag("max-reconcile-rate", "The number of concurrent reconciliations that may be running at one time.").Default("100").Int()
-		clientCacheSize         = app.Flag("client-cache-size", "Maximum number of cached target cluster clients, one per distinct ProviderConfig credential set; the least recently used client is evicted beyond this bound. 0 caches without bound.").Default(strconv.Itoa(kubeclient.DefaultClientCacheSize)).Envar("CLIENT_CACHE_SIZE").Uint()
 		sanitizeSecrets         = app.Flag("sanitize-secrets", "when enabled, redacts Secret data from Object status").Default("false").Envar("SANITIZE_SECRETS").Bool()
 		webhookPort             = app.Flag("webhook-port", "The port the webhook server listens on.").Default("9443").Envar("WEBHOOK_PORT").Int()
 		metricsBindAddress      = app.Flag("metrics-bind-address", "The address the metrics server listens on").Default(":8080").Envar("METRICS_BIND_ADDRESS").String()
@@ -113,7 +110,6 @@ func main() {
 		legacyCSAFieldManagers = app.Flag("legacy-csa-field-managers", "Additional legacy client-side apply Kubernetes field manager names for upgrading to SSA field manager").Default().Strings()
 		enableSecretCache      = app.Flag("enable-secret-cache", "Enable caching of Secret objects. When true, Secrets are served from the informer cache instead of direct API calls. This reduces API server load but increases memory usage.").Default("true").Envar("ENABLE_SECRET_CACHE").Bool()
 	)
-	app.Validate(func(*kingpin.Application) error { return validateClientCacheSize(*clientCacheSize) })
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
 	zl := zap.New(zap.UseDevMode(*debug), UseISO8601())
@@ -204,6 +200,16 @@ func main() {
 	})
 	kingpin.FatalIfError(err, "Cannot create controller manager")
 	kingpin.FatalIfError(mgr.AddReadyzCheck("webhook", mgr.GetWebhookServer().StartedChecker()), "Cannot add webhook server readyz checker to controller manager")
+
+	// The manager client reads through informers that only start with the
+	// manager, so the startup listing goes straight to the API server.
+	sizingClient, err := client.New(mgr.GetConfig(), client.Options{HTTPClient: mgr.GetHTTPClient(), Scheme: mgr.GetScheme(), Mapper: mgr.GetRESTMapper()})
+	kingpin.FatalIfError(err, "Cannot create client to size the client cache")
+	sizingCtx, cancelSizing := context.WithTimeout(context.Background(), clientCacheSizeTimeout)
+	cacheSize, err := clientCacheSize(sizingCtx, log, sizingClient)
+	cancelSizing()
+	kingpin.FatalIfError(err, "Cannot calculate the client cache size")
+
 	mm := managed.NewMRMetricRecorder()
 	sm := statemetrics.NewMRStateMetrics()
 
@@ -232,7 +238,7 @@ func main() {
 		PollJitterPercentage: *pollJitterPercentage,
 		ClientBuilder: kubeclient.NewIdentityAwareBuilder(mgr.GetClient(),
 			kubeclient.WithLogger(log),
-			kubeclient.WithClientCacheSize(int(*clientCacheSize))),
+			kubeclient.WithClientCacheSize(cacheSize)),
 	}
 
 	if *enableManagementPolicies {
@@ -339,13 +345,4 @@ func canWatchCRD(ctx context.Context, mgr manager.Manager) (bool, error) {
 		}
 	}
 	return true, nil
-}
-
-// validateClientCacheSize rejects flag values that do not fit the builder's
-// int bound instead of letting the conversion wrap around.
-func validateClientCacheSize(size uint) error {
-	if size > math.MaxInt {
-		return errors.Errorf("--client-cache-size must not exceed %d", math.MaxInt)
-	}
-	return nil
 }

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -212,9 +212,11 @@ func main() {
 
 	mm := managed.NewMRMetricRecorder()
 	sm := statemetrics.NewMRStateMetrics()
+	cm := kubeclient.NewClientCacheMetrics("provider_kubernetes")
 
 	metrics.Registry.MustRegister(mm)
 	metrics.Registry.MustRegister(sm)
+	metrics.Registry.MustRegister(cm)
 
 	mo := controller.MetricOptions{
 		PollStateMetricInterval: *pollStateMetricInterval,
@@ -238,7 +240,8 @@ func main() {
 		PollJitterPercentage: *pollJitterPercentage,
 		ClientBuilder: kubeclient.NewIdentityAwareBuilder(mgr.GetClient(),
 			kubeclient.WithLogger(log),
-			kubeclient.WithClientCacheSize(cacheSize)),
+			kubeclient.WithClientCacheSize(cacheSize),
+			kubeclient.WithClientCacheMetrics(cm)),
 	}
 
 	if *enableManagementPolicies {

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,8 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/nebius/gosdk v0.2.28
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/spf13/pflag v1.0.10
 	github.com/upbound/up-sdk-go v1.13.0
 	go.uber.org/zap v1.28.0
@@ -108,8 +110,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/pkg/kube/client/cache_test.go
+++ b/pkg/kube/client/cache_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -108,15 +109,14 @@ func pcSpec(kubeconfigSecret, identitySecret string) kconfig.ProviderConfigSpec 
 	return pc
 }
 
-// clientIdentities maps every client to the index of the first call that
-// returned the same instance, so [0, 0] means one reused client and [0, 1]
-// means two distinct clients.
-func clientIdentities(clients []client.Client) []int {
-	ids := make([]int, len(clients))
-	for i, c := range clients {
+// groups maps every item to the index of the first item equal to it, so
+// [0, 0] means one shared client or key and [0, 1] means two distinct ones.
+func groups[T comparable](items []T) []int {
+	ids := make([]int, len(items))
+	for i, it := range items {
 		ids[i] = i
 		for j := range i {
-			if clients[j] == c {
+			if items[j] == it {
 				ids[i] = ids[j]
 				break
 			}
@@ -211,8 +211,138 @@ func TestKubeForProviderConfigCaching(t *testing.T) {
 				clients = append(clients, k)
 			}
 
-			if diff := cmp.Diff(tc.want.clients, clientIdentities(clients)); diff != "" {
+			if diff := cmp.Diff(tc.want.clients, groups(clients)); diff != "" {
 				t.Errorf("KubeForProviderConfig(...): -want client identities, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+// awsSpec references the kubeconfig Secret and uses the AWS web identity of
+// the provider pod.
+func awsSpec(kubeconfigSecret string) kconfig.ProviderConfigSpec {
+	pc := pcSpec(kubeconfigSecret, "")
+	pc.Identity = &kconfig.Identity{
+		Type:                kconfig.IdentityTypeAWSWebIdentityCredentials,
+		ProviderCredentials: kconfig.ProviderCredentials{Source: xpv2.CredentialsSourceInjectedIdentity},
+	}
+	return pc
+}
+
+func TestClientCacheKey(t *testing.T) {
+	errBoom := errors.New("boom")
+	kubeconfigA := kubeconfigFor("https://a.example.org:6443")
+	secrets := map[string]map[string][]byte{
+		"kubeconfig-a":      {"kubeconfig": kubeconfigA},
+		"kubeconfig-a-copy": {"kubeconfig": kubeconfigA},
+		"kubeconfig-b":      {"kubeconfig": kubeconfigFor("https://b.example.org:6443")},
+		"token-a":           {"credentials": []byte("access-token-a")},
+		"token-b":           {"credentials": []byte("access-token-b")},
+	}
+
+	type args struct {
+		specs []kconfig.ProviderConfigSpec
+	}
+	type want struct {
+		groups []int
+		// buildable marks specs whose client can be built without a cloud
+		// environment; for them the keys must group exactly as the clients
+		// KubeForProviderConfig hands out.
+		buildable bool
+		err       error
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"SameSecretSharesKey": {
+			args: args{specs: []kconfig.ProviderConfigSpec{pcSpec("kubeconfig-a", ""), pcSpec("kubeconfig-a", "")}},
+			want: want{groups: []int{0, 0}, buildable: true},
+		},
+		"SameKubeconfigInDifferentSecretsSharesKey": {
+			args: args{specs: []kconfig.ProviderConfigSpec{pcSpec("kubeconfig-a", ""), pcSpec("kubeconfig-a-copy", "")}},
+			want: want{groups: []int{0, 0}, buildable: true},
+		},
+		"DifferentKubeconfigsHaveDistinctKeys": {
+			args: args{specs: []kconfig.ProviderConfigSpec{pcSpec("kubeconfig-a", ""), pcSpec("kubeconfig-b", "")}},
+			want: want{groups: []int{0, 1}, buildable: true},
+		},
+		"IdentityCredentialsArePartOfTheKey": {
+			args: args{specs: []kconfig.ProviderConfigSpec{
+				pcSpec("kubeconfig-a", ""),
+				pcSpec("kubeconfig-a", "token-a"),
+				pcSpec("kubeconfig-a", "token-b"),
+				pcSpec("kubeconfig-a", "token-a"),
+			}},
+			want: want{groups: []int{0, 1, 2, 1}, buildable: true},
+		},
+		"InjectedIdentityIsPartOfTheKey": {
+			args: args{specs: []kconfig.ProviderConfigSpec{
+				pcSpec("kubeconfig-a", ""),
+				awsSpec("kubeconfig-a"),
+				awsSpec("kubeconfig-a-copy"),
+				awsSpec("kubeconfig-b"),
+			}},
+			want: want{groups: []int{0, 1, 1, 3}},
+		},
+		"MissingSecretIsAnError": {
+			args: args{specs: []kconfig.ProviderConfigSpec{pcSpec("missing", "")}},
+			want: want{err: errors.Wrap(errors.Wrap(errBoom, "cannot get credentials secret"), errGetCreds)},
+		},
+		"UnsupportedIdentitySourceIsAnError": {
+			args: args{specs: []kconfig.ProviderConfigSpec{{
+				Credentials: kconfig.ProviderCredentials{Source: xpv2.CredentialsSourceSecret, CommonCredentialSelectors: secretSelector("kubeconfig-a", "kubeconfig")},
+				Identity: &kconfig.Identity{
+					Type:                kconfig.IdentityTypeAWSWebIdentityCredentials,
+					ProviderCredentials: kconfig.ProviderCredentials{Source: xpv2.CredentialsSourceSecret, CommonCredentialSelectors: secretSelector("token-a", "credentials")},
+				},
+			}}},
+			want: want{err: errors.Errorf("%s is not supported as identity source for identity type %s", xpv2.CredentialsSourceSecret, kconfig.IdentityTypeAWSWebIdentityCredentials)},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			local := &test.MockClient{MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+				if _, ok := secrets[key.Name]; !ok {
+					return errBoom
+				}
+				return secretLocalClient(secrets).Get(ctx, key, obj)
+			}}
+			b := NewIdentityAwareBuilder(local, WithClientCacheSize(0))
+
+			keys := make([]string, 0, len(tc.args.specs))
+			var err error
+			for _, pc := range tc.args.specs {
+				var key string
+				if key, err = b.ClientCacheKey(context.Background(), pc); err != nil {
+					break
+				}
+				keys = append(keys, key)
+			}
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Fatalf("ClientCacheKey(...): -want error, +got error:\n%s", diff)
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(tc.want.groups, groups(keys)); diff != "" {
+				t.Errorf("ClientCacheKey(...): -want groups, +got groups:\n%s", diff)
+			}
+			if !tc.want.buildable {
+				return
+			}
+
+			clients := make([]client.Client, 0, len(tc.args.specs))
+			for i, pc := range tc.args.specs {
+				k, _, err := b.KubeForProviderConfig(context.Background(), pc)
+				if err != nil {
+					t.Fatalf("KubeForProviderConfig(...) call %d: unexpected error: %v", i, err)
+				}
+				clients = append(clients, k)
+			}
+			if diff := cmp.Diff(groups(clients), groups(keys)); diff != "" {
+				t.Errorf("ClientCacheKey(...): -want groups (cached clients), +got groups (keys):\n%s", diff)
 			}
 		})
 	}
@@ -251,7 +381,7 @@ func TestKubeForProviderConfigConcurrentBuildsCollapse(t *testing.T) {
 			t.Fatalf("KubeForProviderConfig(...) caller %d: unexpected error: %v", i, err)
 		}
 	}
-	if diff := cmp.Diff(make([]int, callers), clientIdentities(clients)); diff != "" {
+	if diff := cmp.Diff(make([]int, callers), groups(clients)); diff != "" {
 		t.Errorf("KubeForProviderConfig(...): -want every caller to share one client, +got:\n%s", diff)
 	}
 	if diff := cmp.Diff(int32(1), builds.Load()); diff != "" {

--- a/pkg/kube/client/client.go
+++ b/pkg/kube/client/client.go
@@ -89,6 +89,7 @@ type IdentityAwareBuilder struct {
 	// material that produced them, see KubeForProviderConfig.
 	clients   *lru.Cache
 	cacheSize int
+	metrics   *ClientCacheMetrics
 	building  singleflight.Group
 	newClient func(rc *rest.Config) (client.Client, error)
 }
@@ -126,6 +127,7 @@ func NewIdentityAwareBuilder(local client.Client, opts ...BuilderOption) *Identi
 		store:       token.NewReuseSourceStore(),
 		nebiusStore: nebius.NewSDKStore(),
 		cacheSize:   DefaultClientCacheSize,
+		metrics:     NewClientCacheMetrics(""),
 		newClient: func(rc *rest.Config) (client.Client, error) {
 			return client.New(rc, client.Options{})
 		},
@@ -133,9 +135,13 @@ func NewIdentityAwareBuilder(local client.Client, opts ...BuilderOption) *Identi
 	for _, o := range opts {
 		o(b)
 	}
+	// The cache holds its lock while it runs this callback, so it must not
+	// read the cache back; the entries gauge is refreshed after each Add.
 	b.clients = lru.NewWithEvictionFunc(b.cacheSize, func(lru.Key, any) {
+		b.metrics.event(cacheEventEvict)
 		b.log.Debug("Evicted least recently used target cluster client", "cacheSize", b.cacheSize)
 	})
+	b.metrics.size.Set(float64(b.cacheSize))
 	return b
 }
 
@@ -153,9 +159,11 @@ func (b *IdentityAwareBuilder) KubeForProviderConfig(ctx context.Context, pc kco
 		return nil, nil, errors.Wrap(err, "cannot get REST config for provider")
 	}
 	if v, ok := b.clients.Get(r.key); ok {
+		b.metrics.event(cacheEventHit)
 		cached := v.(cachedClient)
 		return cached.kube, rest.CopyConfig(cached.rc), nil
 	}
+	b.metrics.event(cacheEventMiss)
 	// singleflight collapses the thundering herd of concurrent reconciles
 	// racing to build the same client on a cold cache (e.g. provider start).
 	v, err, _ := b.building.Do(r.key, func() (any, error) {
@@ -177,6 +185,7 @@ func (b *IdentityAwareBuilder) KubeForProviderConfig(ctx context.Context, pc kco
 		}
 		cached := cachedClient{kube: k, rc: r.rc}
 		b.clients.Add(r.key, cached)
+		b.metrics.entries.Set(float64(b.clients.Len()))
 		b.log.Debug("Built target cluster client", "cachedClients", b.clients.Len(), "cacheSize", b.cacheSize)
 		return cached, nil
 	})

--- a/pkg/kube/client/client.go
+++ b/pkg/kube/client/client.go
@@ -148,28 +148,35 @@ func NewIdentityAwareBuilder(local client.Client, opts ...BuilderOption) *Identi
 // thus a fresh client; token refresh happens inside the cached transports and
 // needs no rebuild.
 func (b *IdentityAwareBuilder) KubeForProviderConfig(ctx context.Context, pc kconfig.ProviderConfigSpec) (client.Client, *rest.Config, error) {
-	digest := sha256.New()
-	rc, err := b.restForProviderConfig(ctx, pc, digest)
+	r, err := b.resolve(ctx, pc)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "cannot get REST config for provider")
 	}
-	key := hex.EncodeToString(digest.Sum(nil))
-	if v, ok := b.clients.Get(key); ok {
+	if v, ok := b.clients.Get(r.key); ok {
 		cached := v.(cachedClient)
 		return cached.kube, rest.CopyConfig(cached.rc), nil
 	}
 	// singleflight collapses the thundering herd of concurrent reconciles
 	// racing to build the same client on a cold cache (e.g. provider start).
-	v, err, _ := b.building.Do(key, func() (any, error) {
-		if v, ok := b.clients.Get(key); ok {
+	v, err, _ := b.building.Do(r.key, func() (any, error) {
+		if v, ok := b.clients.Get(r.key); ok {
 			return v, nil
 		}
-		k, err := b.newClient(rc)
+		// The token sources the identity injection installs outlive this
+		// call: the built client is cached and reused by later reconciles, so
+		// they must not inherit the per-reconcile cancellation
+		// (crossplane-runtime cancels ctx once the reconcile returns). Each
+		// wrapper bounds its own token fetches instead, with the request
+		// context or an explicit timeout (see gke.WrapRESTConfig).
+		if err := r.injectIdentity(context.WithoutCancel(ctx), r.rc); err != nil {
+			return nil, err
+		}
+		k, err := b.newClient(r.rc)
 		if err != nil {
 			return nil, err
 		}
-		cached := cachedClient{kube: k, rc: rc}
-		b.clients.Add(key, cached)
+		cached := cachedClient{kube: k, rc: r.rc}
+		b.clients.Add(r.key, cached)
 		b.log.Debug("Built target cluster client", "cachedClients", b.clients.Len(), "cacheSize", b.cacheSize)
 		return cached, nil
 	})
@@ -180,6 +187,31 @@ func (b *IdentityAwareBuilder) KubeForProviderConfig(ctx context.Context, pc kco
 	// The config is shared by every caller of this credential set; hand out a
 	// copy so that nobody can mutate it underneath the cached client.
 	return cached.kube, rest.CopyConfig(cached.rc), nil
+}
+
+// ClientCacheKey returns the key under which KubeForProviderConfig caches the
+// client for the given provider config: a digest of the credential material
+// read through the builder's local client (credential source and kubeconfig,
+// then identity type, source and credentials). Provider configs with the same
+// key share one cached client, so the number of distinct keys among a set of
+// provider configs is the number of clients the builder holds for them.
+func (b *IdentityAwareBuilder) ClientCacheKey(ctx context.Context, pc kconfig.ProviderConfigSpec) (string, error) {
+	r, err := b.resolve(ctx, pc)
+	if err != nil {
+		return "", err
+	}
+	return r.key, nil
+}
+
+// resolved is a provider config resolved against the local cluster: the cache
+// key its credential material digests to, the REST config built from the
+// kubeconfig, and the identity injection still to be applied to that config.
+// Resolving reads credentials and runs on every reconcile; injecting the
+// identity installs token sources and runs once per built client.
+type resolved struct {
+	key            string
+	rc             *rest.Config
+	injectIdentity func(ctx context.Context, rc *rest.Config) error
 }
 
 // digestWrite feeds client-defining material into the cache-key digest,
@@ -193,11 +225,12 @@ func digestWrite(d hash.Hash, material ...[]byte) {
 	}
 }
 
-// restForProviderConfig returns the *rest.config for the given provider
-// config. Every input that shapes the resulting config (credential source,
-// extracted credential bytes, identity type and credentials) is also written
-// to digest, which callers use as the client cache key.
-func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kconfig.ProviderConfigSpec, digest hash.Hash) (*rest.Config, error) { // nolint:gocyclo
+// resolve returns the cache key, the REST config and the identity injection
+// for the given provider config. Every input that shapes the resulting client
+// (credential source, extracted credential bytes, identity type, source and
+// credentials) is written to the digest the key is taken from.
+func (b *IdentityAwareBuilder) resolve(ctx context.Context, pc kconfig.ProviderConfigSpec) (resolved, error) {
+	digest := sha256.New()
 	var (
 		rc  *rest.Config
 		err error
@@ -208,23 +241,23 @@ func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kco
 	case xpv2.CredentialsSourceInjectedIdentity:
 		rc, err = rest.InClusterConfig()
 		if err != nil {
-			return nil, errors.Wrap(err, errCreateRestConfig)
+			return resolved{}, errors.Wrap(err, errCreateRestConfig)
 		}
 		digestWrite(digest, []byte(cd.Source))
 	default:
 		kc, err := resource.CommonCredentialExtractor(ctx, cd.Source, b.local, cd.CommonCredentialSelectors)
 		if err != nil {
-			return nil, errors.Wrap(err, errGetCreds)
+			return resolved{}, errors.Wrap(err, errGetCreds)
 		}
 		digestWrite(digest, []byte(cd.Source), kc)
 
 		ac, err = clientcmd.Load(kc)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to load kubeconfig")
+			return resolved{}, errors.Wrap(err, "failed to load kubeconfig")
 		}
 
 		if rc, err = fromAPIConfig(ac); err != nil {
-			return nil, errors.Wrap(err, errCreateRestConfig)
+			return resolved{}, errors.Wrap(err, errCreateRestConfig)
 		}
 	}
 
@@ -235,113 +268,113 @@ func (b *IdentityAwareBuilder) restForProviderConfig(ctx context.Context, pc kco
 	// priority and fairness instead.
 	rc.QPS = -1
 
-	// The token sources the identity wrappers install outlive this call: the
-	// built client is cached and reused by later reconciles, so they must not
-	// inherit the per-reconcile cancellation (crossplane-runtime cancels ctx
-	// once the reconcile returns). Credential reads above stay bound to ctx.
-	// Each wrapper bounds its own token fetches instead, with the request
-	// context or an explicit timeout (see gke.WrapRESTConfig).
-	wrapCtx := context.WithoutCancel(ctx)
-
+	inject := func(context.Context, *rest.Config) error { return nil }
 	if id := pc.Identity; id != nil {
 		digestWrite(digest, []byte(id.Type), []byte(id.Source))
-		switch id.Type {
-		case kconfig.IdentityTypeGoogleApplicationCredentials:
-			switch id.Source { //nolint:exhaustive
-			case xpv2.CredentialsSourceInjectedIdentity:
-				if err := gke.WrapRESTConfig(wrapCtx, rc, nil, gke.DefaultScopes...); err != nil {
-					return nil, errors.Wrap(err, errInjectGoogleCredentials)
-				}
-			default:
-				creds, err := resource.CommonCredentialExtractor(ctx, id.Source, b.local, id.CommonCredentialSelectors)
-				if err != nil {
-					return nil, errors.Wrap(err, errExtractGoogleCredentials)
-				}
-				digestWrite(digest, creds)
-
-				if err := gke.WrapRESTConfig(wrapCtx, rc, creds, gke.DefaultScopes...); err != nil {
-					return nil, errors.Wrap(err, errInjectGoogleCredentials)
-				}
-			}
-		case kconfig.IdentityTypeAzureServicePrincipalCredentials, kconfig.IdentityTypeAzureWorkloadIdentityCredentials:
-			switch id.Source { //nolint:exhaustive
-			case xpv2.CredentialsSourceInjectedIdentity:
-				return nil, errors.Errorf("%s is not supported as identity source for identity type %s",
-					xpv2.CredentialsSourceInjectedIdentity, kconfig.IdentityTypeAzureServicePrincipalCredentials)
-			default:
-				creds, err := resource.CommonCredentialExtractor(ctx, id.Source, b.local, id.CommonCredentialSelectors)
-				if err != nil {
-					return nil, errors.Wrap(err, errExtractAzureCredentials)
-				}
-				digestWrite(digest, creds)
-
-				if err := azure.WrapRESTConfig(wrapCtx, rc, creds, id.Type); err != nil {
-					return nil, errors.Wrap(err, errInjectAzureCredentials)
-				}
-			}
-		case kconfig.IdentityTypeUpboundTokens:
-			switch id.Source { //nolint:exhaustive
-			case xpv2.CredentialsSourceInjectedIdentity:
-				return nil, errors.Errorf("%s is not supported as identity source for identity type %s",
-					xpv2.CredentialsSourceInjectedIdentity, kconfig.IdentityTypeUpboundTokens)
-			default:
-				staticToken, err := resource.CommonCredentialExtractor(ctx, id.Source, b.local, id.CommonCredentialSelectors)
-				if err != nil {
-					return nil, errors.Wrap(err, errExtractUpboundCredentials)
-				}
-				digestWrite(digest, staticToken)
-
-				// We trim the token to remove any leading/trailing whitespace
-				// which may have been added especially when stringData field
-				// is used while creating the secret.
-				if err := upbound.WrapRESTConfig(wrapCtx, rc, strings.TrimSpace(string(staticToken)), b.store); err != nil {
-					return nil, errors.Wrap(err, errInjectUpboundCredentials)
-				}
-			}
-		case kconfig.IdentityTypeAWSWebIdentityCredentials:
-			switch id.Source { //nolint:exhaustive
-			case xpv2.CredentialsSourceInjectedIdentity:
-				// Extract the cluster name from the provided kubeconfig.
-				// We need the actual cluster name (or ARN) for the presigned URL,
-				// not the random endpoint ID from the server URL.
-				var clusterName string
-				if ac != nil && ac.CurrentContext != "" {
-					if ctxConfig := ac.Contexts[ac.CurrentContext]; ctxConfig != nil {
-						clusterName = ctxConfig.Cluster
-					}
-				}
-				digestWrite(digest, []byte(clusterName))
-				// AWS Web Identity credentials use the default AWS credentials chain
-				// which includes IRSA (IAM Roles for Service Accounts) via environment variables:
-				// AWS_ROLE_ARN, AWS_WEB_IDENTITY_TOKEN_FILE, AWS_REGION
-				if err := aws.WrapRESTConfig(wrapCtx, rc, clusterName); err != nil {
-					return nil, errors.Wrap(err, errInjectAWSCredentials)
-				}
-			default:
-				return nil, errors.Errorf("%s is not supported as identity source for identity type %s",
-					id.Source, kconfig.IdentityTypeAWSWebIdentityCredentials)
-			}
-		case kconfig.IdentityTypeNebiusServiceAccountCredentials:
-			switch id.Source { //nolint:exhaustive
-			case xpv2.CredentialsSourceInjectedIdentity:
-				return nil, errors.Errorf("%s is not supported as identity source for identity type %s",
-					xpv2.CredentialsSourceInjectedIdentity, kconfig.IdentityTypeNebiusServiceAccountCredentials)
-			default:
-				creds, err := resource.CommonCredentialExtractor(ctx, id.Source, b.local, id.CommonCredentialSelectors)
-				if err != nil {
-					return nil, errors.Wrap(err, errExtractNebiusCredentials)
-				}
-				digestWrite(digest, creds)
-				if err := nebius.WrapRESTConfig(wrapCtx, rc, creds, b.nebiusStore); err != nil {
-					return nil, errors.Wrap(err, errInjectNebiusCredentials)
-				}
-			}
-		default:
-			return nil, errors.Errorf("unknown identity type: %s", id.Type)
+		if inject, err = b.identityInjector(ctx, id, ac, digest); err != nil {
+			return resolved{}, err
 		}
 	}
+	return resolved{key: hex.EncodeToString(digest.Sum(nil)), rc: rc, injectIdentity: inject}, nil
+}
 
-	return rc, nil
+// identityInjector extracts the credentials of the identity, writing them to
+// the digest, and returns the function that injects the identity into a REST
+// config built from the kubeconfig ac. Only the injection installs token
+// sources, so it is deferred until a client is actually built.
+func (b *IdentityAwareBuilder) identityInjector(ctx context.Context, id *kconfig.Identity, ac *api.Config, digest hash.Hash) (func(ctx context.Context, rc *rest.Config) error, error) { //nolint:gocyclo // one case per identity type and source
+	switch id.Type {
+	case kconfig.IdentityTypeGoogleApplicationCredentials:
+		switch id.Source { //nolint:exhaustive
+		case xpv2.CredentialsSourceInjectedIdentity:
+			return func(ctx context.Context, rc *rest.Config) error {
+				return errors.Wrap(gke.WrapRESTConfig(ctx, rc, nil, gke.DefaultScopes...), errInjectGoogleCredentials)
+			}, nil
+		default:
+			creds, err := resource.CommonCredentialExtractor(ctx, id.Source, b.local, id.CommonCredentialSelectors)
+			if err != nil {
+				return nil, errors.Wrap(err, errExtractGoogleCredentials)
+			}
+			digestWrite(digest, creds)
+			return func(ctx context.Context, rc *rest.Config) error {
+				return errors.Wrap(gke.WrapRESTConfig(ctx, rc, creds, gke.DefaultScopes...), errInjectGoogleCredentials)
+			}, nil
+		}
+	case kconfig.IdentityTypeAzureServicePrincipalCredentials, kconfig.IdentityTypeAzureWorkloadIdentityCredentials:
+		switch id.Source { //nolint:exhaustive
+		case xpv2.CredentialsSourceInjectedIdentity:
+			return nil, errors.Errorf("%s is not supported as identity source for identity type %s",
+				xpv2.CredentialsSourceInjectedIdentity, kconfig.IdentityTypeAzureServicePrincipalCredentials)
+		default:
+			creds, err := resource.CommonCredentialExtractor(ctx, id.Source, b.local, id.CommonCredentialSelectors)
+			if err != nil {
+				return nil, errors.Wrap(err, errExtractAzureCredentials)
+			}
+			digestWrite(digest, creds)
+			return func(ctx context.Context, rc *rest.Config) error {
+				return errors.Wrap(azure.WrapRESTConfig(ctx, rc, creds, id.Type), errInjectAzureCredentials)
+			}, nil
+		}
+	case kconfig.IdentityTypeUpboundTokens:
+		switch id.Source { //nolint:exhaustive
+		case xpv2.CredentialsSourceInjectedIdentity:
+			return nil, errors.Errorf("%s is not supported as identity source for identity type %s",
+				xpv2.CredentialsSourceInjectedIdentity, kconfig.IdentityTypeUpboundTokens)
+		default:
+			staticToken, err := resource.CommonCredentialExtractor(ctx, id.Source, b.local, id.CommonCredentialSelectors)
+			if err != nil {
+				return nil, errors.Wrap(err, errExtractUpboundCredentials)
+			}
+			digestWrite(digest, staticToken)
+			// We trim the token to remove any leading/trailing whitespace
+			// which may have been added especially when stringData field
+			// is used while creating the secret.
+			trimmed := strings.TrimSpace(string(staticToken))
+			return func(ctx context.Context, rc *rest.Config) error {
+				return errors.Wrap(upbound.WrapRESTConfig(ctx, rc, trimmed, b.store), errInjectUpboundCredentials)
+			}, nil
+		}
+	case kconfig.IdentityTypeAWSWebIdentityCredentials:
+		switch id.Source { //nolint:exhaustive
+		case xpv2.CredentialsSourceInjectedIdentity:
+			// Extract the cluster name from the provided kubeconfig.
+			// We need the actual cluster name (or ARN) for the presigned URL,
+			// not the random endpoint ID from the server URL.
+			var clusterName string
+			if ac != nil && ac.CurrentContext != "" {
+				if ctxConfig := ac.Contexts[ac.CurrentContext]; ctxConfig != nil {
+					clusterName = ctxConfig.Cluster
+				}
+			}
+			digestWrite(digest, []byte(clusterName))
+			// AWS Web Identity credentials use the default AWS credentials chain
+			// which includes IRSA (IAM Roles for Service Accounts) via environment variables:
+			// AWS_ROLE_ARN, AWS_WEB_IDENTITY_TOKEN_FILE, AWS_REGION
+			return func(ctx context.Context, rc *rest.Config) error {
+				return errors.Wrap(aws.WrapRESTConfig(ctx, rc, clusterName), errInjectAWSCredentials)
+			}, nil
+		default:
+			return nil, errors.Errorf("%s is not supported as identity source for identity type %s",
+				id.Source, kconfig.IdentityTypeAWSWebIdentityCredentials)
+		}
+	case kconfig.IdentityTypeNebiusServiceAccountCredentials:
+		switch id.Source { //nolint:exhaustive
+		case xpv2.CredentialsSourceInjectedIdentity:
+			return nil, errors.Errorf("%s is not supported as identity source for identity type %s",
+				xpv2.CredentialsSourceInjectedIdentity, kconfig.IdentityTypeNebiusServiceAccountCredentials)
+		default:
+			creds, err := resource.CommonCredentialExtractor(ctx, id.Source, b.local, id.CommonCredentialSelectors)
+			if err != nil {
+				return nil, errors.Wrap(err, errExtractNebiusCredentials)
+			}
+			digestWrite(digest, creds)
+			return func(ctx context.Context, rc *rest.Config) error {
+				return errors.Wrap(nebius.WrapRESTConfig(ctx, rc, creds, b.nebiusStore), errInjectNebiusCredentials)
+			}, nil
+		}
+	default:
+		return nil, errors.Errorf("unknown identity type: %s", id.Type)
+	}
 }
 
 func fromAPIConfig(c *api.Config) (*rest.Config, error) {

--- a/pkg/kube/client/metrics.go
+++ b/pkg/kube/client/metrics.go
@@ -22,7 +22,8 @@ const (
 
 	// cacheEventHit is a lookup served by a cached client.
 	cacheEventHit = "hit"
-	// cacheEventMiss is a lookup that found no cached client and built one.
+	// cacheEventMiss is a lookup that found no cached client; concurrent
+	// misses of one credential set collapse into a single build.
 	cacheEventMiss = "miss"
 	// cacheEventEvict is a cached client dropped to stay within the bound.
 	cacheEventEvict = "evict"
@@ -62,7 +63,7 @@ func NewClientCacheMetrics(namespace string) *ClientCacheMetrics {
 			Namespace: namespace,
 			Subsystem: metricsSubsystem,
 			Name:      "events_total",
-			Help:      "Client cache lookups by outcome: hit (cached client reused), miss (no cached client, one was built), evict (least recently used client dropped to stay within the bound).",
+			Help:      "Client cache lookups by outcome: hit (cached client reused), miss (no cached client at lookup time; concurrent misses of one credential set share a single build), evict (least recently used client dropped to stay within the bound).",
 		}, []string{"event"}),
 	}
 	for _, event := range []string{cacheEventHit, cacheEventMiss, cacheEventEvict} {
@@ -90,9 +91,12 @@ func (m *ClientCacheMetrics) event(event string) {
 }
 
 // WithClientCacheMetrics makes the builder report its client cache to m.
-// Without it the builder reports to collectors that are never registered.
+// Without it, or with a nil m, the builder reports to collectors that are
+// never registered.
 func WithClientCacheMetrics(m *ClientCacheMetrics) BuilderOption {
 	return func(b *IdentityAwareBuilder) {
-		b.metrics = m
+		if m != nil {
+			b.metrics = m
+		}
 	}
 }

--- a/pkg/kube/client/metrics.go
+++ b/pkg/kube/client/metrics.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 The Crossplane Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricsSubsystem = "client_cache"
+
+	// cacheEventHit is a lookup served by a cached client.
+	cacheEventHit = "hit"
+	// cacheEventMiss is a lookup that found no cached client and built one.
+	cacheEventMiss = "miss"
+	// cacheEventEvict is a cached client dropped to stay within the bound.
+	cacheEventEvict = "evict"
+)
+
+// ClientCacheMetrics reports on the target cluster client cache of an
+// IdentityAwareBuilder. Register it with the metrics registry and hand it to
+// the builder with WithClientCacheMetrics. The series carry no per-credential
+// or per-ProviderConfig labels; a sustained rate of evictions is the signal
+// that the cache bound is too small for the credential sets in use.
+type ClientCacheMetrics struct {
+	size    prometheus.Gauge
+	entries prometheus.Gauge
+	events  *prometheus.CounterVec
+}
+
+// NewClientCacheMetrics returns collectors for a client cache, named
+// <namespace>_client_cache_size, <namespace>_client_cache_entries and
+// <namespace>_client_cache_events_total, with every event series initialised
+// to zero so that rates can be computed from the first scrape. The namespace
+// identifies the provider that embeds the builder, e.g. provider_kubernetes.
+func NewClientCacheMetrics(namespace string) *ClientCacheMetrics {
+	m := &ClientCacheMetrics{
+		size: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: metricsSubsystem,
+			Name:      "size",
+			Help:      "Bound on the number of cached target cluster clients, one per distinct credential set. 0 when unbounded.",
+		}),
+		entries: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: metricsSubsystem,
+			Name:      "entries",
+			Help:      "Number of target cluster clients currently cached.",
+		}),
+		events: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: metricsSubsystem,
+			Name:      "events_total",
+			Help:      "Client cache lookups by outcome: hit (cached client reused), miss (no cached client, one was built), evict (least recently used client dropped to stay within the bound).",
+		}, []string{"event"}),
+	}
+	for _, event := range []string{cacheEventHit, cacheEventMiss, cacheEventEvict} {
+		m.events.WithLabelValues(event)
+	}
+	return m
+}
+
+// Describe implements prometheus.Collector.
+func (m *ClientCacheMetrics) Describe(ch chan<- *prometheus.Desc) {
+	m.size.Describe(ch)
+	m.entries.Describe(ch)
+	m.events.Describe(ch)
+}
+
+// Collect implements prometheus.Collector.
+func (m *ClientCacheMetrics) Collect(ch chan<- prometheus.Metric) {
+	m.size.Collect(ch)
+	m.entries.Collect(ch)
+	m.events.Collect(ch)
+}
+
+func (m *ClientCacheMetrics) event(event string) {
+	m.events.WithLabelValues(event).Inc()
+}
+
+// WithClientCacheMetrics makes the builder report its client cache to m.
+// Without it the builder reports to collectors that are never registered.
+func WithClientCacheMetrics(m *ClientCacheMetrics) BuilderOption {
+	return func(b *IdentityAwareBuilder) {
+		b.metrics = m
+	}
+}

--- a/pkg/kube/client/metrics_test.go
+++ b/pkg/kube/client/metrics_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 The Crossplane Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	kconfig "github.com/crossplane-contrib/provider-kubernetes/pkg/kube/config"
+)
+
+// cacheReport is what the collectors expose after a sequence of lookups.
+type cacheReport struct {
+	size    float64
+	entries float64
+	hits    float64
+	misses  float64
+	evicts  float64
+}
+
+func value(t *testing.T, m prometheus.Metric) float64 {
+	t.Helper()
+	var out dto.Metric
+	if err := m.Write(&out); err != nil {
+		t.Fatalf("Write(...): unexpected error: %v", err)
+	}
+	if out.GetCounter() != nil {
+		return out.GetCounter().GetValue()
+	}
+	return out.GetGauge().GetValue()
+}
+
+func report(t *testing.T, m *ClientCacheMetrics) cacheReport {
+	t.Helper()
+	return cacheReport{
+		size:    value(t, m.size),
+		entries: value(t, m.entries),
+		hits:    value(t, m.events.WithLabelValues(cacheEventHit)),
+		misses:  value(t, m.events.WithLabelValues(cacheEventMiss)),
+		evicts:  value(t, m.events.WithLabelValues(cacheEventEvict)),
+	}
+}
+
+func TestClientCacheMetrics(t *testing.T) {
+	secrets := map[string]map[string][]byte{
+		"kubeconfig-a": {"kubeconfig": kubeconfigFor("https://a.example.org:6443")},
+		"kubeconfig-b": {"kubeconfig": kubeconfigFor("https://b.example.org:6443")},
+	}
+
+	type args struct {
+		cacheSize int
+		calls     []kconfig.ProviderConfigSpec
+	}
+	type want struct {
+		report cacheReport
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"FreshBuilderReportsZeroes": {
+			args: args{cacheSize: DefaultClientCacheSize},
+			want: want{report: cacheReport{size: DefaultClientCacheSize}},
+		},
+		"RepeatedLookupsHit": {
+			args: args{
+				cacheSize: DefaultClientCacheSize,
+				calls:     []kconfig.ProviderConfigSpec{pcSpec("kubeconfig-a", ""), pcSpec("kubeconfig-a", ""), pcSpec("kubeconfig-a", "")},
+			},
+			want: want{report: cacheReport{size: DefaultClientCacheSize, entries: 1, hits: 2, misses: 1}},
+		},
+		"DistinctCredentialsMissAndFill": {
+			args: args{
+				cacheSize: DefaultClientCacheSize,
+				calls:     []kconfig.ProviderConfigSpec{pcSpec("kubeconfig-a", ""), pcSpec("kubeconfig-b", "")},
+			},
+			want: want{report: cacheReport{size: DefaultClientCacheSize, entries: 2, misses: 2}},
+		},
+		"OverflowEvicts": {
+			args: args{
+				cacheSize: 1,
+				calls:     []kconfig.ProviderConfigSpec{pcSpec("kubeconfig-a", ""), pcSpec("kubeconfig-b", ""), pcSpec("kubeconfig-a", "")},
+			},
+			want: want{report: cacheReport{size: 1, entries: 1, misses: 3, evicts: 2}},
+		},
+		"UnboundedReportsZeroSize": {
+			args: args{
+				cacheSize: 0,
+				calls:     []kconfig.ProviderConfigSpec{pcSpec("kubeconfig-a", ""), pcSpec("kubeconfig-b", "")},
+			},
+			want: want{report: cacheReport{entries: 2, misses: 2}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			m := NewClientCacheMetrics("provider_test")
+			b := NewIdentityAwareBuilder(secretLocalClient(secrets), WithClientCacheSize(tc.args.cacheSize), WithClientCacheMetrics(m))
+
+			for i, pc := range tc.args.calls {
+				if _, _, err := b.KubeForProviderConfig(context.Background(), pc); err != nil {
+					t.Fatalf("KubeForProviderConfig(...) call %d: unexpected error: %v", i, err)
+				}
+			}
+
+			if diff := cmp.Diff(tc.want.report, report(t, m), cmp.AllowUnexported(cacheReport{})); diff != "" {
+				t.Errorf("client cache metrics: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestClientCacheMetricsRegister(t *testing.T) {
+	cases := map[string]struct {
+		metrics *ClientCacheMetrics
+	}{
+		"CollectorsRegisterOnce": {metrics: NewClientCacheMetrics("provider_kubernetes")},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			reg := prometheus.NewPedanticRegistry()
+			if err := reg.Register(tc.metrics); err != nil {
+				t.Fatalf("Register(...): unexpected error: %v", err)
+			}
+			families, err := reg.Gather()
+			if err != nil {
+				t.Fatalf("Gather(): unexpected error: %v", err)
+			}
+			names := make([]string, 0, len(families))
+			for _, f := range families {
+				names = append(names, f.GetName())
+			}
+			want := []string{"provider_kubernetes_client_cache_entries", "provider_kubernetes_client_cache_events_total", "provider_kubernetes_client_cache_size"}
+			if diff := cmp.Diff(want, names); diff != "" {
+				t.Errorf("Gather(): -want families, +got families:\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/kube/client/sizing.go
+++ b/pkg/kube/client/sizing.go
@@ -23,10 +23,16 @@ import (
 	kconfig "github.com/crossplane-contrib/provider-kubernetes/pkg/kube/config"
 )
 
-// clientCacheKeyWorkers bounds the number of provider configs whose keys
-// ClientCacheSizeFor derives at once, and with it the credential reads in
-// flight against the local cluster.
-const clientCacheKeyWorkers = 16
+const (
+	// clientCacheKeyWorkers bounds the number of provider configs whose keys
+	// ClientCacheSizeFor derives at once, and with it the credential reads in
+	// flight against the local cluster.
+	clientCacheKeyWorkers = 16
+	// minClientCacheHeadroom is the least headroom the cache bound leaves
+	// above the credential sets counted, so that a few rotations or provider
+	// configs created after startup fit even in a small fleet.
+	minClientCacheHeadroom = 4
+)
 
 // ClientCacheSizing is the outcome of ClientCacheSizeFor.
 type ClientCacheSizing struct {
@@ -44,10 +50,10 @@ type ClientCacheSizing struct {
 
 // ClientCacheSizeFor sizes the client cache of an IdentityAwareBuilder for the
 // given provider configs so that every one of them keeps its client cached:
-// one entry per distinct credential set plus a tenth of headroom, rounded up,
-// for sets whose credentials rotate (the client built from the old
-// credentials occupies an entry until it ages out), and never below
-// DefaultClientCacheSize. Keys are derived by
+// one entry per distinct credential set plus headroom of a tenth, rounded up
+// and at least four, for sets whose credentials rotate (the client built from
+// the old credentials occupies an entry until it ages out) and for configs
+// created later, and never below DefaultClientCacheSize. Keys are derived by
 // a builder over local, exactly as KubeForProviderConfig derives them, so
 // configs that share credential material count once; up to
 // clientCacheKeyWorkers configs are derived at a time. A config whose key
@@ -88,8 +94,9 @@ func ClientCacheSizeFor(ctx context.Context, local client.Client, pcs []kconfig.
 	return s, nil
 }
 
-// clientCacheSizeFor returns the cache bound for n credential sets: n plus a
-// tenth of headroom, rounded up, and never below DefaultClientCacheSize.
+// clientCacheSizeFor returns the cache bound for n credential sets: n plus
+// headroom of a tenth, rounded up and at least minClientCacheHeadroom, and
+// never below DefaultClientCacheSize.
 func clientCacheSizeFor(n int) int {
-	return max(DefaultClientCacheSize, n+(n+9)/10)
+	return max(DefaultClientCacheSize, n+max((n+9)/10, minClientCacheHeadroom))
 }

--- a/pkg/kube/client/sizing.go
+++ b/pkg/kube/client/sizing.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The Crossplane Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kconfig "github.com/crossplane-contrib/provider-kubernetes/pkg/kube/config"
+)
+
+// ClientCacheSizing is the outcome of ClientCacheSizeFor.
+type ClientCacheSizing struct {
+	// CredentialSets is the number of distinct clients the provider configs
+	// resolve to: configs whose credential material digests to the same key
+	// share one client.
+	CredentialSets int
+	// Unresolved is the number of provider configs whose key could not be
+	// derived, for example because the Secret they reference is missing.
+	// Each is assumed to be a credential set of its own.
+	Unresolved int
+	// Size is the resulting client cache bound.
+	Size int
+}
+
+// ClientCacheSizeFor sizes the client cache of an IdentityAwareBuilder for the
+// given provider configs so that every one of them keeps its client cached:
+// one entry per distinct credential set plus a tenth of headroom, rounded up,
+// for sets whose credentials rotate (the client built from the old
+// credentials occupies an entry until it ages out), and never below
+// DefaultClientCacheSize. Keys are derived by a builder over local, exactly as
+// KubeForProviderConfig derives them, so configs that share credential
+// material count once. A config whose key cannot be derived is counted as a
+// credential set of its own, so the estimate errs high; an expired context is
+// the only error, since a partial derivation would not be a bound at all.
+func ClientCacheSizeFor(ctx context.Context, local client.Client, pcs []kconfig.ProviderConfigSpec) (ClientCacheSizing, error) {
+	b := NewIdentityAwareBuilder(local)
+	keys := make(map[string]struct{}, len(pcs))
+	s := ClientCacheSizing{}
+	for _, pc := range pcs {
+		key, err := b.ClientCacheKey(ctx, pc)
+		if err != nil {
+			if ctx.Err() != nil {
+				return ClientCacheSizing{}, errors.Wrap(err, "cannot derive client cache keys")
+			}
+			s.Unresolved++
+			continue
+		}
+		keys[key] = struct{}{}
+	}
+	s.CredentialSets = len(keys)
+	s.Size = clientCacheSizeFor(s.CredentialSets + s.Unresolved)
+	return s, nil
+}
+
+// clientCacheSizeFor returns the cache bound for n credential sets: n plus a
+// tenth of headroom, rounded up, and never below DefaultClientCacheSize.
+func clientCacheSizeFor(n int) int {
+	return max(DefaultClientCacheSize, n+(n+9)/10)
+}

--- a/pkg/kube/client/sizing.go
+++ b/pkg/kube/client/sizing.go
@@ -17,10 +17,16 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kconfig "github.com/crossplane-contrib/provider-kubernetes/pkg/kube/config"
 )
+
+// clientCacheKeyWorkers bounds the number of provider configs whose keys
+// ClientCacheSizeFor derives at once, and with it the credential reads in
+// flight against the local cluster.
+const clientCacheKeyWorkers = 16
 
 // ClientCacheSizing is the outcome of ClientCacheSizeFor.
 type ClientCacheSizing struct {
@@ -41,27 +47,43 @@ type ClientCacheSizing struct {
 // one entry per distinct credential set plus a tenth of headroom, rounded up,
 // for sets whose credentials rotate (the client built from the old
 // credentials occupies an entry until it ages out), and never below
-// DefaultClientCacheSize. Keys are derived by a builder over local, exactly as
-// KubeForProviderConfig derives them, so configs that share credential
-// material count once. A config whose key cannot be derived is counted as a
-// credential set of its own, so the estimate errs high; an expired context is
-// the only error, since a partial derivation would not be a bound at all.
+// DefaultClientCacheSize. Keys are derived by
+// a builder over local, exactly as KubeForProviderConfig derives them, so
+// configs that share credential material count once; up to
+// clientCacheKeyWorkers configs are derived at a time. A config whose key
+// cannot be derived is counted as a credential set of its own, so the estimate
+// errs high; an expired context is the only error, since a partial derivation
+// would not be a bound at all.
 func ClientCacheSizeFor(ctx context.Context, local client.Client, pcs []kconfig.ProviderConfigSpec) (ClientCacheSizing, error) {
 	b := NewIdentityAwareBuilder(local)
-	keys := make(map[string]struct{}, len(pcs))
-	s := ClientCacheSizing{}
-	for _, pc := range pcs {
-		key, err := b.ClientCacheKey(ctx, pc)
-		if err != nil {
-			if ctx.Err() != nil {
-				return ClientCacheSizing{}, errors.Wrap(err, "cannot derive client cache keys")
+	// An empty key marks a config whose key could not be derived.
+	keys := make([]string, len(pcs))
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(clientCacheKeyWorkers)
+	for i, pc := range pcs {
+		g.Go(func() error {
+			key, err := b.ClientCacheKey(ctx, pc)
+			if err != nil && ctx.Err() != nil {
+				return errors.Wrap(err, "cannot derive client cache keys")
 			}
+			keys[i] = key
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return ClientCacheSizing{}, err
+	}
+
+	distinct := make(map[string]struct{}, len(keys))
+	s := ClientCacheSizing{}
+	for _, key := range keys {
+		if key == "" {
 			s.Unresolved++
 			continue
 		}
-		keys[key] = struct{}{}
+		distinct[key] = struct{}{}
 	}
-	s.CredentialSets = len(keys)
+	s.CredentialSets = len(distinct)
 	s.Size = clientCacheSizeFor(s.CredentialSets + s.Unresolved)
 	return s, nil
 }

--- a/pkg/kube/client/sizing_test.go
+++ b/pkg/kube/client/sizing_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026 The Crossplane Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+
+	kconfig "github.com/crossplane-contrib/provider-kubernetes/pkg/kube/config"
+)
+
+// distinctSpecs returns n provider configs that each reference a Secret with
+// a kubeconfig of its own, plus the Secrets serving them.
+func distinctSpecs(n int) ([]kconfig.ProviderConfigSpec, map[string]map[string][]byte) {
+	specs := make([]kconfig.ProviderConfigSpec, 0, n)
+	secrets := make(map[string]map[string][]byte, n)
+	for i := range n {
+		name := fmt.Sprintf("kubeconfig-%d", i)
+		secrets[name] = map[string][]byte{"kubeconfig": kubeconfigFor(fmt.Sprintf("https://%d.example.org:6443", i))}
+		specs = append(specs, pcSpec(name, ""))
+	}
+	return specs, secrets
+}
+
+func TestClientCacheSizeFor(t *testing.T) {
+	type args struct {
+		ctx   context.Context
+		local client.Client
+		pcs   []kconfig.ProviderConfigSpec
+	}
+	type want struct {
+		sizing ClientCacheSizing
+		err    bool
+	}
+
+	tenSpecs, tenSecrets := distinctSpecs(10)
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"NoProviderConfigsUseTheDefault": {
+			args: args{ctx: context.Background(), local: secretLocalClient(nil)},
+			want: want{sizing: ClientCacheSizing{Size: DefaultClientCacheSize}},
+		},
+		"SharedCredentialsCountOnce": {
+			args: args{
+				ctx:   context.Background(),
+				local: secretLocalClient(tenSecrets),
+				pcs:   []kconfig.ProviderConfigSpec{tenSpecs[0], tenSpecs[0], tenSpecs[1]},
+			},
+			want: want{sizing: ClientCacheSizing{CredentialSets: 2, Size: DefaultClientCacheSize}},
+		},
+		"HeadroomAboveTheDefault": {
+			args: args{ctx: context.Background(), local: secretLocalClient(tenSecrets), pcs: tenSpecs},
+			want: want{sizing: ClientCacheSizing{CredentialSets: 10, Size: 11}},
+		},
+		"UnresolvedCountsAsItsOwnSet": {
+			args: args{
+				ctx:   context.Background(),
+				local: secretLocalClient(tenSecrets),
+				pcs:   append([]kconfig.ProviderConfigSpec{pcSpec("missing", "")}, tenSpecs...),
+			},
+			want: want{sizing: ClientCacheSizing{CredentialSets: 10, Unresolved: 1, Size: 13}},
+		},
+		"ExpiredContextIsAnError": {
+			args: args{
+				ctx: cancelled,
+				local: &test.MockClient{MockGet: func(ctx context.Context, _ client.ObjectKey, _ client.Object) error {
+					return ctx.Err()
+				}},
+				pcs: tenSpecs,
+			},
+			want: want{err: true},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := ClientCacheSizeFor(tc.args.ctx, tc.args.local, tc.args.pcs)
+			if diff := cmp.Diff(tc.want.err, err != nil); diff != "" {
+				t.Fatalf("ClientCacheSizeFor(...): -want error, +got error (%v):\n%s", err, diff)
+			}
+			if diff := cmp.Diff(tc.want.sizing, got); diff != "" {
+				t.Errorf("ClientCacheSizeFor(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestClientCacheSizeForCount(t *testing.T) {
+	cases := map[string]struct {
+		credentialSets int
+		want           int
+	}{
+		"NoneIsTheDefault":       {credentialSets: 0, want: DefaultClientCacheSize},
+		"BelowTheDefault":        {credentialSets: 7, want: DefaultClientCacheSize},
+		"HeadroomLeavesDefault":  {credentialSets: 8, want: 9},
+		"HeadroomRoundsUp":       {credentialSets: 12, want: 14},
+		"HeadroomIsProportional": {credentialSets: 100, want: 110},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if diff := cmp.Diff(tc.want, clientCacheSizeFor(tc.credentialSets)); diff != "" {
+				t.Errorf("clientCacheSizeFor(%d): -want, +got:\n%s", tc.credentialSets, diff)
+			}
+		})
+	}
+}

--- a/pkg/kube/client/sizing_test.go
+++ b/pkg/kube/client/sizing_test.go
@@ -16,7 +16,9 @@ package client
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,6 +41,27 @@ func distinctSpecs(n int) ([]kconfig.ProviderConfigSpec, map[string]map[string][
 	return specs, secrets
 }
 
+// gatedLocalClient serves the Secrets only once clientCacheKeyWorkers reads
+// are in flight, so that a sequential derivation never completes.
+func gatedLocalClient(secrets map[string]map[string][]byte) client.Client {
+	var inFlight atomic.Int32
+	released := make(chan struct{})
+	serve := secretLocalClient(secrets).(*test.MockClient).MockGet
+	return &test.MockClient{
+		MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+			if inFlight.Add(1) == clientCacheKeyWorkers {
+				close(released)
+			}
+			select {
+			case <-released:
+				return serve(ctx, key, obj)
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+	}
+}
+
 func TestClientCacheSizeFor(t *testing.T) {
 	type args struct {
 		ctx   context.Context
@@ -51,8 +74,11 @@ func TestClientCacheSizeFor(t *testing.T) {
 	}
 
 	tenSpecs, tenSecrets := distinctSpecs(10)
+	workerSpecs, workerSecrets := distinctSpecs(clientCacheKeyWorkers)
 	cancelled, cancel := context.WithCancel(context.Background())
 	cancel()
+	bounded, cancelBounded := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancelBounded)
 
 	cases := map[string]struct {
 		args args
@@ -81,6 +107,10 @@ func TestClientCacheSizeFor(t *testing.T) {
 				pcs:   append([]kconfig.ProviderConfigSpec{pcSpec("missing", "")}, tenSpecs...),
 			},
 			want: want{sizing: ClientCacheSizing{CredentialSets: 10, Unresolved: 1, Size: 13}},
+		},
+		"KeysAreDerivedConcurrently": {
+			args: args{ctx: bounded, local: gatedLocalClient(workerSecrets), pcs: workerSpecs},
+			want: want{sizing: ClientCacheSizing{CredentialSets: clientCacheKeyWorkers, Size: 18}},
 		},
 		"ExpiredContextIsAnError": {
 			args: args{

--- a/pkg/kube/client/sizing_test.go
+++ b/pkg/kube/client/sizing_test.go
@@ -98,7 +98,7 @@ func TestClientCacheSizeFor(t *testing.T) {
 		},
 		"HeadroomAboveTheDefault": {
 			args: args{ctx: context.Background(), local: secretLocalClient(tenSecrets), pcs: tenSpecs},
-			want: want{sizing: ClientCacheSizing{CredentialSets: 10, Size: 11}},
+			want: want{sizing: ClientCacheSizing{CredentialSets: 10, Size: 14}},
 		},
 		"UnresolvedCountsAsItsOwnSet": {
 			args: args{
@@ -106,11 +106,11 @@ func TestClientCacheSizeFor(t *testing.T) {
 				local: secretLocalClient(tenSecrets),
 				pcs:   append([]kconfig.ProviderConfigSpec{pcSpec("missing", "")}, tenSpecs...),
 			},
-			want: want{sizing: ClientCacheSizing{CredentialSets: 10, Unresolved: 1, Size: 13}},
+			want: want{sizing: ClientCacheSizing{CredentialSets: 10, Unresolved: 1, Size: 15}},
 		},
 		"KeysAreDerivedConcurrently": {
 			args: args{ctx: bounded, local: gatedLocalClient(workerSecrets), pcs: workerSpecs},
-			want: want{sizing: ClientCacheSizing{CredentialSets: clientCacheKeyWorkers, Size: 18}},
+			want: want{sizing: ClientCacheSizing{CredentialSets: clientCacheKeyWorkers, Size: clientCacheKeyWorkers + minClientCacheHeadroom}},
 		},
 		"ExpiredContextIsAnError": {
 			args: args{
@@ -138,21 +138,29 @@ func TestClientCacheSizeFor(t *testing.T) {
 }
 
 func TestClientCacheSizeForCount(t *testing.T) {
-	cases := map[string]struct {
+	type args struct {
 		credentialSets int
-		want           int
+	}
+	type want struct {
+		size int
+	}
+
+	cases := map[string]struct {
+		args args
+		want want
 	}{
-		"NoneIsTheDefault":       {credentialSets: 0, want: DefaultClientCacheSize},
-		"BelowTheDefault":        {credentialSets: 7, want: DefaultClientCacheSize},
-		"HeadroomLeavesDefault":  {credentialSets: 8, want: 9},
-		"HeadroomRoundsUp":       {credentialSets: 12, want: 14},
-		"HeadroomIsProportional": {credentialSets: 100, want: 110},
+		"NoneIsTheDefault":      {args: args{credentialSets: 0}, want: want{size: DefaultClientCacheSize}},
+		"FloorWithinTheDefault": {args: args{credentialSets: 4}, want: want{size: DefaultClientCacheSize}},
+		"FloorAboveTheDefault":  {args: args{credentialSets: 7}, want: want{size: 11}},
+		"FloorBeatsATenth":      {args: args{credentialSets: 20}, want: want{size: 24}},
+		"TenthRoundsUp":         {args: args{credentialSets: 42}, want: want{size: 47}},
+		"TenthIsProportional":   {args: args{credentialSets: 100}, want: want{size: 110}},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			if diff := cmp.Diff(tc.want, clientCacheSizeFor(tc.credentialSets)); diff != "" {
-				t.Errorf("clientCacheSizeFor(%d): -want, +got:\n%s", tc.credentialSets, diff)
+			if diff := cmp.Diff(tc.want.size, clientCacheSizeFor(tc.args.credentialSets)); diff != "" {
+				t.Errorf("clientCacheSizeFor(%d): -want, +got:\n%s", tc.args.credentialSets, diff)
 			}
 		})
 	}


### PR DESCRIPTION
### Description of your changes
* The default bound of 8 cached target cluster clients cannot suit every
control plane: too small silently reverts to per-reconcile discovery
(#541), too large keeps rotated-out clients alive. Size it from the
cluster instead, and drop the --client-cache-size flag: the number is
knowable, so there is nothing left for an operator to guess.

  ClientCacheSizeFor in pkg/kube/client derives the cache key of every
  ProviderConfig spec through the builder, sixteen at a time, counts
  distinct credential sets, adds headroom of ten percent or four entries,
  whichever is larger, for rotating credentials and ProviderConfigs
  created later, and floors the result at DefaultClientCacheSize; a spec
  whose key cannot be derived counts as a set of its own. The calculator takes specs, so provider-helm
  can reuse it with its own kinds - [commit](https://github.com/crossplane-contrib/provider-kubernetes/pull/560/changes/edf52f0d8ed5365701bb490369b5e287a46a9620)
  
  At startup the provider lists its legacy ProviderConfig plus the
  namespaced ProviderConfig and ClusterProviderConfig kinds through a
  direct client (the manager client cannot read before the manager
  starts), within a 300 second budget, and logs the resulting size. A kind
  whose CRD is not installed contributes nothing; failing to build that
  client, to list the ProviderConfigs or to read their credentials within
  the budget fails startup: a partial count would not be a bound, so
  there is no fallback to the default (the issue proposed falling back
  with a warning).

* Split IdentityAwareBuilder's REST config construction into resolving a
ProviderConfig (read the credential material, digest it into the cache
key, build the REST config from the kubeconfig) and injecting the
identity (install the token sources), and run the injection only when a
client is actually built. A cache hit no longer runs the identity
wrappers, whose work (Google credential parsing, the AWS default
credential chain, Nebius SDK setup) was thrown away with the fresh REST
config on every reconcile. Export the key as ClientCacheKey so that sizing code can derive it
through the builder instead of mirroring the digest - [commit](https://github.com/crossplane-contrib/provider-kubernetes/pull/560/changes/8d43b3b7af34a0716447ec017db4903650f8dfa6)

* A too-small client cache degrades silently to per-reconcile discovery
(#541), with only a Debug log on eviction. Put collectors on
IdentityAwareBuilder so that every importer of pkg/kube/client can
register them next to its other recorders:

  \<ns\>_client_cache_size          gauge    the bound in effect (0 = unbounded)
  \<ns\>_client_cache_entries       gauge    clients currently cached
  \<ns\>_client_cache_events_total  counter  event="hit|miss|evict"

  The namespace is the embedding provider's own, as with upjet's metrics;
  provider-kubernetes registers them as provider_kubernetes_client_cache_*.
  No per-credential or per-ProviderConfig labels. A sustained eviction
  rate is the signal that the credential sets in use no longer fit the
  bound.
  
  Every event series is initialised to zero so that rates work from the
  first scrape. The entries gauge is refreshed after each Add rather than
  in the eviction callback, which the cache runs under its own lock - [commit](https://github.com/crossplane-contrib/provider-kubernetes/pull/560/changes/86d59b5fabf9be105ee2865577fc68ae3e32aa8e)

* Review follow-ups, one commit each: derive the keys concurrently and
raise the startup budget from 30 to 300 seconds - [commit](https://github.com/crossplane-contrib/provider-kubernetes/pull/560/changes/afb141dabadff65a262f6e9f18760900ca8adac7);
floor the headroom at four entries and describe the LRU churn on overflow
in the README (every new client evicts the least recently used one, whose
next reconcile rebuilds it) - [commit](https://github.com/crossplane-contrib/provider-kubernetes/pull/560/changes/9d45b5d95fa14cea07f5fc27cef384d01d17acba); reword the `miss` help
text, since concurrent misses of one credential set share a single build,
and ignore a nil metrics collector - [commit](https://github.com/crossplane-contrib/provider-kubernetes/pull/560/changes/4decd374ee2211347c5451c8f5305bd8bb67a631)

Fixes #559 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Run E2E tests, added unit tests, added log lines stating the computed cache size

[contribution process]: https://git.io/fj2m9

