### PR TITLE
feat: add noRequeue option to Readiness to suppress periodic poll

### DIFF
--- a/apis/cluster/object/v1alpha2/types.go
+++ b/apis/cluster/object/v1alpha2/types.go
@@ -151,6 +151,14 @@ type Readiness struct {
 	//  `object.status.conditions.all(x, x.status == "True")` mimics the behavior of the AllTrue readiness policy
 	//  `object.status.conditions.exists(c, c.type == "condition1" && c.status == "True" )` checks just one condition
 	CelQuery string `json:"celQuery,omitempty"`
+
+	// NoRequeue suppresses the periodic poll requeue once the object is ready and up-to-date.
+	// The object will still be reconciled immediately on any spec change via the watch mechanism.
+	// This is useful for large fleets of stable resources where periodic Observe() calls to the
+	// remote cluster are unnecessary overhead.
+	// +optional
+	// +kubebuilder:default=false
+	NoRequeue bool `json:"noRequeue,omitempty"`
 }
 
 // ConnectionDetail represents an entry in the connection secret for an Object

--- a/apis/namespaced/object/v1alpha1/types.go
+++ b/apis/namespaced/object/v1alpha1/types.go
@@ -151,6 +151,14 @@ type Readiness struct {
 	//  `object.status.conditions.all(x, x.status == "True")` mimics the behavior of the AllTrue readiness policy
 	//  `object.status.conditions.exists(c, c.type == "condition1" && c.status == "True" )` checks just one condition
 	CelQuery string `json:"celQuery,omitempty"`
+
+	// NoRequeue suppresses the periodic poll requeue once the object is ready and up-to-date.
+	// The object will still be reconciled immediately on any spec change via the watch mechanism.
+	// This is useful for large fleets of stable resources where periodic Observe() calls to the
+	// remote cluster are unnecessary overhead.
+	// +optional
+	// +kubebuilder:default=false
+	NoRequeue bool `json:"noRequeue,omitempty"`
 }
 
 // ConnectionDetail represents an entry in the connection secret for an Object

--- a/internal/controller/cluster/object/object.go
+++ b/internal/controller/cluster/object/object.go
@@ -153,6 +153,29 @@ type ResourceSyncer interface {
 	SyncResource(ctx context.Context, obj *v1alpha2.Object, desired *unstructured.Unstructured) (*unstructured.Unstructured, error)
 }
 
+// buildPollIntervalHook returns a PollIntervalHook that:
+// - returns 0 (no requeue) when noRequeue is true and the resource is ready,
+// - uses a short 30s interval when the resource is not yet ready,
+// - otherwise uses the configured poll interval with jitter.
+func buildPollIntervalHook(pollJitterPercentage uint) managed.PollIntervalHook {
+	return func(mg resource.Managed, pollInterval time.Duration) time.Duration {
+		obj, ok := mg.(*v1alpha2.Object)
+		if ok && obj.Spec.Readiness.NoRequeue && mg.GetCondition(xpv2.TypeReady).Status == v1.ConditionTrue {
+			// Suppress periodic requeue for stable resources with noRequeue: true.
+			// Watch events will still trigger an immediate reconcile on any spec change.
+			return 0
+		}
+		if mg.GetCondition(xpv2.TypeReady).Status != v1.ConditionTrue {
+			// If the resource is not ready, poll more frequently to avoid delaying time to readiness.
+			pollInterval = 30 * time.Second
+		}
+		pollJitter := time.Duration(float64(pollInterval) * (float64(pollJitterPercentage) / 100.0))
+		// This is the same as runtime default poll interval with jitter, see:
+		// https://github.com/crossplane/crossplane-runtime/blob/7fcb8c5cad6fc4abb6649813b92ab92e1832d368/pkg/reconciler/managed/reconciler.go#L573
+		return pollInterval + time.Duration((rand.Float64()-0.5)*2*float64(pollJitter)) //nolint G404 // No need for secure randomness
+	}
+}
+
 // Setup adds a controller that reconciles Object managed resources.
 func Setup(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Builder, sanitizeSecrets bool, removeManagedFields bool, pollJitterPercentage uint, legacyCSAFieldManagers []string) error { // nolint:gocyclo // Too many branches due to alpha features, hopefully we can clean them up after we graduate them.
 	if clientBuilder == nil {
@@ -164,16 +187,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Buil
 	reconcilerOptions := []managed.ReconcilerOption{
 		managed.WithFinalizer(&objFinalizer{client: mgr.GetClient()}),
 		managed.WithPollInterval(o.PollInterval),
-		managed.WithPollIntervalHook(func(mg resource.Managed, pollInterval time.Duration) time.Duration {
-			if mg.GetCondition(xpv2.TypeReady).Status != v1.ConditionTrue {
-				// If the resource is not ready, we should poll more frequently not to delay time to readiness.
-				pollInterval = 30 * time.Second
-			}
-			pollJitter := time.Duration(float64(pollInterval) * (float64(pollJitterPercentage) / 100.0))
-			// This is the same as runtime default poll interval with jitter, see:
-			// https://github.com/crossplane/crossplane-runtime/blob/7fcb8c5cad6fc4abb6649813b92ab92e1832d368/pkg/reconciler/managed/reconciler.go#L573
-			return pollInterval + time.Duration((rand.Float64()-0.5)*2*float64(pollJitter)) //nolint G404 // No need for secure randomness
-		}),
+		managed.WithPollIntervalHook(buildPollIntervalHook(pollJitterPercentage)),
 		managed.WithLogger(l),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))), //nolint:staticcheck // SA1019: keeping the legacy events API until crossplane-runtime's event package moves to GetEventRecorder
 		managed.WithMetricRecorder(o.MetricOptions.MRMetrics),

--- a/internal/controller/cluster/object/object_test.go
+++ b/internal/controller/cluster/object/object_test.go
@@ -2123,3 +2123,69 @@ func TestLoggableRedactsSecretData(t *testing.T) {
 		})
 	}
 }
+
+func TestPollIntervalHook(t *testing.T) {
+	const basePollInterval = 10 * time.Minute
+
+	cases := map[string]struct {
+		obj           *v1alpha2.Object
+		wantZero      bool
+		wantShortPoll bool
+	}{
+		"DefaultNoRequeueFalseReadyTrue": {
+			obj: kubernetesObject(func(o *v1alpha2.Object) {
+				o.Spec.Readiness = v1alpha2.Readiness{NoRequeue: false}
+				o.Status.SetConditions(xpv2.Available())
+			}),
+			wantZero:      false,
+			wantShortPoll: false,
+		},
+		"NoRequeueTrueReadyFalse": {
+			obj: kubernetesObject(func(o *v1alpha2.Object) {
+				o.Spec.Readiness = v1alpha2.Readiness{NoRequeue: true}
+				o.Status.SetConditions(xpv2.Unavailable())
+			}),
+			wantZero:      false,
+			wantShortPoll: true,
+		},
+		"NoRequeueTrueReadyTrue": {
+			obj: kubernetesObject(func(o *v1alpha2.Object) {
+				o.Spec.Readiness = v1alpha2.Readiness{NoRequeue: true}
+				o.Status.SetConditions(xpv2.Available())
+			}),
+			wantZero:      true,
+			wantShortPoll: false,
+		},
+		"NotReadyUsesShortPoll": {
+			obj: kubernetesObject(func(o *v1alpha2.Object) {
+				o.Status.SetConditions(xpv2.Unavailable())
+			}),
+			wantZero:      false,
+			wantShortPoll: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			hook := buildPollIntervalHook(0)
+			got := hook(tc.obj, basePollInterval)
+			switch {
+			case tc.wantZero:
+				if got != 0 {
+					t.Errorf("expected poll interval 0 (no requeue), got %s", got)
+				}
+			case tc.wantShortPoll:
+				if got > 30*time.Second {
+					t.Errorf("expected fast poll (<= 30s) for not-ready resource, got %s", got)
+				}
+			default:
+				if got == 0 {
+					t.Errorf("expected non-zero poll interval, got 0")
+				}
+				if got > basePollInterval {
+					t.Errorf("expected poll interval <= base %s, got %s", basePollInterval, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/controller/namespaced/object/object.go
+++ b/internal/controller/namespaced/object/object.go
@@ -154,6 +154,29 @@ type ResourceSyncer interface {
 	SyncResource(ctx context.Context, obj *v1alpha1.Object, desired *unstructured.Unstructured) (*unstructured.Unstructured, error)
 }
 
+// buildPollIntervalHook returns a PollIntervalHook that:
+// - returns 0 (no requeue) when noRequeue is true and the resource is ready,
+// - uses a short 30s interval when the resource is not yet ready,
+// - otherwise uses the configured poll interval with jitter.
+func buildPollIntervalHook(pollJitterPercentage uint) managed.PollIntervalHook {
+	return func(mg resource.Managed, pollInterval time.Duration) time.Duration {
+		obj, ok := mg.(*v1alpha1.Object)
+		if ok && obj.Spec.Readiness.NoRequeue && mg.GetCondition(xpv2.TypeReady).Status == v1.ConditionTrue {
+			// Suppress periodic requeue for stable resources with noRequeue: true.
+			// Watch events will still trigger an immediate reconcile on any spec change.
+			return 0
+		}
+		if mg.GetCondition(xpv2.TypeReady).Status != v1.ConditionTrue {
+			// If the resource is not ready, poll more frequently to avoid delaying time to readiness.
+			pollInterval = 30 * time.Second
+		}
+		pollJitter := time.Duration(float64(pollInterval) * (float64(pollJitterPercentage) / 100.0))
+		// This is the same as runtime default poll interval with jitter, see:
+		// https://github.com/crossplane/crossplane-runtime/blob/7fcb8c5cad6fc4abb6649813b92ab92e1832d368/pkg/reconciler/managed/reconciler.go#L573
+		return pollInterval + time.Duration((rand.Float64()-0.5)*2*float64(pollJitter)) //nolint G404 // No need for secure randomness
+	}
+}
+
 // Setup adds a controller that reconciles Object managed resources.
 func Setup(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Builder, sanitizeSecrets bool, removeManagedFields bool, pollJitterPercentage uint, legacyCSAFieldManagers []string) error { // nolint:gocyclo // Too many branches due to alpha features, hopefully we can clean them up after we graduate them.
 	if clientBuilder == nil {
@@ -165,16 +188,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Buil
 	reconcilerOptions := []managed.ReconcilerOption{
 		managed.WithFinalizer(&objFinalizer{client: mgr.GetClient()}),
 		managed.WithPollInterval(o.PollInterval),
-		managed.WithPollIntervalHook(func(mg resource.Managed, pollInterval time.Duration) time.Duration {
-			if mg.GetCondition(xpv2.TypeReady).Status != v1.ConditionTrue {
-				// If the resource is not ready, we should poll more frequently not to delay time to readiness.
-				pollInterval = 30 * time.Second
-			}
-			pollJitter := time.Duration(float64(pollInterval) * (float64(pollJitterPercentage) / 100.0))
-			// This is the same as runtime default poll interval with jitter, see:
-			// https://github.com/crossplane/crossplane-runtime/blob/7fcb8c5cad6fc4abb6649813b92ab92e1832d368/pkg/reconciler/managed/reconciler.go#L573
-			return pollInterval + time.Duration((rand.Float64()-0.5)*2*float64(pollJitter)) //nolint G404 // No need for secure randomness
-		}),
+		managed.WithPollIntervalHook(buildPollIntervalHook(pollJitterPercentage)),
 		managed.WithLogger(l),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))), //nolint:staticcheck // SA1019: keeping the legacy events API until crossplane-runtime's event package moves to GetEventRecorder
 		managed.WithMetricRecorder(o.MetricOptions.MRMetrics),

--- a/internal/controller/namespaced/object/object_test.go
+++ b/internal/controller/namespaced/object/object_test.go
@@ -2124,3 +2124,69 @@ func TestLoggableRedactsSecretData(t *testing.T) {
 		})
 	}
 }
+
+func TestPollIntervalHook(t *testing.T) {
+	const basePollInterval = 10 * time.Minute
+
+	cases := map[string]struct {
+		obj           *objv1alpha1.Object
+		wantZero      bool
+		wantShortPoll bool
+	}{
+		"DefaultNoRequeueFalseReadyTrue": {
+			obj: kubernetesObject(func(o *objv1alpha1.Object) {
+				o.Spec.Readiness = objv1alpha1.Readiness{NoRequeue: false}
+				o.Status.SetConditions(xpv2.Available())
+			}),
+			wantZero:      false,
+			wantShortPoll: false,
+		},
+		"NoRequeueTrueReadyFalse": {
+			obj: kubernetesObject(func(o *objv1alpha1.Object) {
+				o.Spec.Readiness = objv1alpha1.Readiness{NoRequeue: true}
+				o.Status.SetConditions(xpv2.Unavailable())
+			}),
+			wantZero:      false,
+			wantShortPoll: true,
+		},
+		"NoRequeueTrueReadyTrue": {
+			obj: kubernetesObject(func(o *objv1alpha1.Object) {
+				o.Spec.Readiness = objv1alpha1.Readiness{NoRequeue: true}
+				o.Status.SetConditions(xpv2.Available())
+			}),
+			wantZero:      true,
+			wantShortPoll: false,
+		},
+		"NotReadyUsesShortPoll": {
+			obj: kubernetesObject(func(o *objv1alpha1.Object) {
+				o.Status.SetConditions(xpv2.Unavailable())
+			}),
+			wantZero:      false,
+			wantShortPoll: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			hook := buildPollIntervalHook(0)
+			got := hook(tc.obj, basePollInterval)
+			switch {
+			case tc.wantZero:
+				if got != 0 {
+					t.Errorf("expected poll interval 0 (no requeue), got %s", got)
+				}
+			case tc.wantShortPoll:
+				if got > 30*time.Second {
+					t.Errorf("expected fast poll (<= 30s) for not-ready resource, got %s", got)
+				}
+			default:
+				if got == 0 {
+					t.Errorf("expected non-zero poll interval, got 0")
+				}
+				if got > basePollInterval {
+					t.Errorf("expected poll interval <= base %s, got %s", basePollInterval, got)
+				}
+			}
+		})
+	}
+}

--- a/package/crds/kubernetes.crossplane.io_objects.yaml
+++ b/package/crds/kubernetes.crossplane.io_objects.yaml
@@ -656,6 +656,14 @@ spec:
                        `object.status.conditions.all(x, x.status == "True")` mimics the behavior of the AllTrue readiness policy
                        `object.status.conditions.exists(c, c.type == "condition1" && c.status == "True" )` checks just one condition
                     type: string
+                  noRequeue:
+                    default: false
+                    description: |-
+                      NoRequeue suppresses the periodic poll requeue once the object is ready and up-to-date.
+                      The object will still be reconciled immediately on any spec change via the watch mechanism.
+                      This is useful for large fleets of stable resources where periodic Observe() calls to the
+                      remote cluster are unnecessary overhead.
+                    type: boolean
                   policy:
                     default: SuccessfulCreate
                     description: Policy defines how the Object's readiness condition


### PR DESCRIPTION
### Description of your changes

Adds a `noRequeue` boolean field to the `Readiness` struct (both cluster and namespaced Object types). When set to `true` and the object has `Ready: True`, the `WithPollIntervalHook` returns `0`, suppressing the periodic poll requeue. The provider will not contact the remote cluster again until a spec change triggers a reconcile via the watch mechanism.

This is a pure opt-in performance knob — default is `false`, preserving all existing behaviour. It is orthogonal to `policy` and works with any readiness policy.

Example usage:
```yaml
readiness:
  policy: SuccessfulCreate
  noRequeue: true
```

Fixes #561

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- Unit tests added for `buildPollIntervalHook` in both `internal/controller/cluster/object/object_test.go` and `internal/controller/namespaced/object/object_test.go`, covering all four combinations of `noRequeue` and `Ready` state.
- `go test ./...` passes cleanly.
- CRD YAML regenerated via `go generate ./apis/...`.

[contribution process]: https://git.io/fj2m9