### PR TITLE
Promote Watches feature to beta

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -272,8 +272,8 @@ func main() {
 	}
 
 	if *enableWatches {
-		o.Features.Enable(features.EnableAlphaWatches)
-		log.Info("Alpha feature enabled", "flag", features.EnableAlphaWatches)
+		o.Features.Enable(features.EnableBetaWatches)
+		log.Info("Beta feature enabled", "flag", features.EnableBetaWatches)
 	}
 
 	if *enableServerSideApply {

--- a/internal/controller/cluster/object/object.go
+++ b/internal/controller/cluster/object/object.go
@@ -206,7 +206,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Buil
 		WithOptions(o.ForControllerRuntime()).
 		For(&v1alpha2.Object{})
 
-	if o.Features.Enabled(features.EnableAlphaWatches) {
+	if o.Features.Enabled(features.EnableBetaWatches) {
 		ca := mgr.GetCache()
 		if err := ca.IndexField(context.Background(), &v1alpha2.Object{}, resourceRefGVKsIndex, IndexByProviderGVK); err != nil {
 			return errors.Wrap(err, "cannot add index for object reference GVKs")

--- a/internal/controller/namespaced/object/object.go
+++ b/internal/controller/namespaced/object/object.go
@@ -207,7 +207,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, clientBuilder kubeclient.Buil
 		WithOptions(o.ForControllerRuntime()).
 		For(&v1alpha1.Object{})
 
-	if o.Features.Enabled(features.EnableAlphaWatches) {
+	if o.Features.Enabled(features.EnableBetaWatches) {
 		ca := mgr.GetCache()
 		if err := ca.IndexField(context.Background(), &v1alpha1.Object{}, resourceRefGVKsIndex, IndexByProviderGVK); err != nil {
 			return errors.Wrap(err, "cannot add index for object reference GVKs")

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -20,9 +20,9 @@ import "github.com/crossplane/crossplane-runtime/v2/pkg/feature"
 
 // Feature flags.
 const (
-	// EnableAlphaWatches enables alpha support for watching referenced and
+	// EnableBetaWatches enables beta support for watching referenced and
 	// managed resources.
-	EnableAlphaWatches feature.Flag = "EnableAlphaWatches"
+	EnableBetaWatches feature.Flag = "EnableBetaWatches"
 	// EnableBetaServerSideApply enables beta support for Server Side Apply.
 	EnableBetaServerSideApply feature.Flag = "EnableBetaServerSideApply"
 )


### PR DESCRIPTION
### Description of your changes
Promotes Watches feature to beta
Fixes #410

I've kept the default flag value as `false` as both the behavior and the resource consumption of the provider changes with this feature enabled, I'm happy to change it to `true` as it's a beta feature now but I'd like to get a second opinion
@bobh66 what do you think as you've opened the #410 ?

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

[contribution process]: https://git.io/fj2m9
